### PR TITLE
Remove employer attribution from public artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Draft for discussion. https://github.com/kenithphilip/Tessera
 
 ## Author
 
-Kenith Philip, Fivetran Security Engineering.
+Kenith Philip.
 
 Questions, corrections, and implementation feedback are welcome via
 GitHub issues once the repository is published publicly.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -178,7 +178,7 @@ before v1.0.0 is experimental. We will bump:
 v1.0.0 is gated on:
 
 - Completion of items 1, 2, 4, 7, and either 13 or 14 above.
-- At least one independent production deployment (not Fivetran-only).
+- At least one independent production deployment.
 - Stable `TrustLabel` serialization format that we are willing to
   freeze as an interop standard.
 

--- a/papers/two-primitives-for-agent-security-meshes.md
+++ b/papers/two-primitives-for-agent-security-meshes.md
@@ -2,7 +2,7 @@
 
 ## Trust-Labeled Context and Schema-Enforced Dual-LLM Execution
 
-**Author:** Kenith Philip, Fivetran Security Engineering
+**Author:** Kenith Philip
 
 **Status:** Draft for discussion with OWASP Agentic AI, IETF WIMSE, and agent
 mesh implementers.


### PR DESCRIPTION
Tessera is a personal project. This drops the employer label from the three public artifacts that carried it:

- `README.md`: author line
- `papers/two-primitives-for-agent-security-meshes.md`: byline
- `docs/ROADMAP.md`: v1.0.0 gate wording

### How tested

Grepped the tree for `Fivetran|fivetran|DeepHub` after the edits. Zero hits.