### PR TITLE
Add SecretRegistry credential isolation at the proxy boundary

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,7 @@ src/tessera/
 ├── events.py           SecurityEvent with pluggable sinks
 ├── telemetry.py        optional OpenTelemetry instrumentation
 ├── proxy.py            FastAPI sidecar reference
+├── redaction.py        SecretRegistry for credential isolation at the proxy
 └── cli.py              `tessera serve` entrypoint
 ```
 
@@ -155,9 +156,34 @@ to the configured upstream LLM, and gates any proposed tool calls
 through the policy engine. Denied calls are returned alongside the
 allowed ones in a `tessera` field on the response.
 
-This module is ~160 lines and is meant to be treated as a specification,
+The proxy also runs secret redaction on both directions when a
+`SecretRegistry` (see `redaction.py`) is configured: outbound messages
+are scrubbed before the upstream LLM sees them, and inbound responses
+are walked with `redact_nested` before being handed back to the caller.
+A `SECRET_REDACTED` security event fires whenever a hit occurs, so
+incident response sees the near-miss.
+
+This module is ~200 lines and is meant to be treated as a specification,
 not a production artifact. Production deployments should port the
 primitives into a Rust data-plane proxy such as agentgateway.
+
+### `redaction.py`
+
+Credential isolation at the proxy boundary. `SecretRegistry` holds a
+set of named secrets that must never cross the proxy boundary.
+`registry.redact(text)` replaces every registered value with a
+`<REDACTED:NAME>` marker. `redact_nested(obj, registry)` walks a JSON
+shaped payload and rewrites string leaves in place. The registry
+refuses to register secrets shorter than 8 characters to avoid
+false-positive matches on benign substrings.
+
+The pattern is the GitHub Agent Workflow Firewall approach: the proxy
+holds the real credentials, and any attempt to move them into an LLM
+prompt or back out through an LLM response is rewritten to the opaque
+marker. This is defense-in-depth for agents that still hold real
+credentials in process; the right long-term answer is to give the
+agent process placeholder tokens and substitute on egress to
+downstream services.
 
 ### `cli.py`
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,11 +57,21 @@ Ordered by security payoff per engineering effort.
    credibility-building thing we can do for the paper, and the paper
    explicitly flags it as missing.
 
-2. **Credential isolation at the proxy.** GitHub Agent Workflow Firewall
-   pattern: the proxy holds real API keys, the agent process receives
-   only placeholder tokens, the proxy substitutes on outbound calls.
-   Prevents credential exfiltration via prompt injection. Roughly 100
-   lines and one real attack class closed.
+2. **Credential isolation at the proxy.** A first cut has landed in
+   `tessera.redaction`. The proxy now accepts a `SecretRegistry` and
+   scrubs every occurrence of the registered values from outbound
+   chat-completion payloads and inbound responses, emitting a
+   `SECRET_REDACTED` security event on every hit. This closes the
+   "agent accidentally includes a real token in an LLM prompt" and
+   "LLM response echoes a known secret back to the agent" classes.
+
+   What is NOT yet built and is still the endgame here: full
+   substitute-on-egress for downstream tool calls. The production
+   pattern wants the agent process to hold only placeholder tokens and
+   have the proxy substitute real values as requests leave the trust
+   boundary toward downstream services. That requires the proxy to
+   mediate tool traffic (not just chat completions), which is a
+   larger architectural change tracked as a follow-up.
 
 3. **Token budget enforcement per principal per day.** Denial-of-wallet
    defense. One counter, one policy check, ~50 lines.

--- a/src/tessera/__init__.py
+++ b/src/tessera/__init__.py
@@ -21,6 +21,7 @@ from tessera.quarantine import (
     split_by_trust,
     strict_worker,
 )
+from tessera.redaction import Secret, SecretRegistry, redact_nested
 from tessera.registry import ToolRegistry
 from tessera.signing import (
     HMACSigner,
@@ -51,6 +52,8 @@ __all__ = [
     "Policy",
     "PolicyViolation",
     "QuarantinedExecutor",
+    "Secret",
+    "SecretRegistry",
     "SecurityEvent",
     "SigningNotAvailable",
     "ToolRegistry",
@@ -61,6 +64,7 @@ __all__ = [
     "WorkerSchemaViolation",
     "emit_event",
     "make_segment",
+    "redact_nested",
     "register_sink",
     "sign_label",
     "split_by_trust",

--- a/src/tessera/events.py
+++ b/src/tessera/events.py
@@ -34,6 +34,7 @@ class EventKind(StrEnum):
     POLICY_DENY = "policy_deny"
     WORKER_SCHEMA_VIOLATION = "worker_schema_violation"
     LABEL_VERIFY_FAILURE = "label_verify_failure"
+    SECRET_REDACTED = "secret_redacted"
 
 
 @dataclass(frozen=True)

--- a/src/tessera/proxy.py
+++ b/src/tessera/proxy.py
@@ -22,8 +22,10 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 from tessera.context import Context, LabeledSegment
+from tessera.events import EventKind, SecurityEvent, emit as emit_event
 from tessera.labels import Origin, TrustLabel, TrustLevel
 from tessera.policy import Policy
+from tessera.redaction import SecretRegistry, redact_nested
 from tessera.telemetry import proxy_request_span, upstream_span
 
 UpstreamFn = Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]
@@ -69,10 +71,27 @@ def create_app(
     key: bytes,
     upstream: UpstreamFn,
     policy: Policy | None = None,
+    secrets: SecretRegistry | None = None,
 ) -> FastAPI:
-    """Build a FastAPI app wired to the given HMAC key, upstream, and policy."""
+    """Build a FastAPI app wired to the given HMAC key, upstream, and policy.
+
+    Args:
+        key: HMAC key used to verify every inbound label.
+        upstream: Async callable that takes an OpenAI-shaped payload and
+            returns the upstream response as a dict.
+        policy: Taint-tracking policy applied to proposed tool calls.
+            Defaults to an empty policy where every tool requires USER
+            trust unless overridden per request.
+        secrets: Optional credential registry. When provided, the proxy
+            scrubs every occurrence of the registered values from both
+            outbound messages (before upstream sees them) and inbound
+            responses (before the agent sees them), and emits a
+            ``SECRET_REDACTED`` event whenever a hit fires. Leave unset
+            on deployments that do not need credential isolation.
+    """
     app = FastAPI(title="Tessera Proxy", version="0.0.1")
     effective_policy = policy or Policy()
+    secret_registry = secrets or SecretRegistry()
 
     @app.post("/v1/chat/completions")
     async def chat_completions(req: ChatRequest) -> dict[str, Any]:
@@ -95,15 +114,46 @@ def create_app(
         for tool in req.tools:
             effective_policy.require(tool.name, TrustLevel(tool.required_trust))
 
+        outbound_messages: list[dict[str, Any]] = []
+        egress_principal = context.principal
+        for m in req.messages:
+            rendered = _render_for_upstream(m, context)
+            if len(secret_registry) > 0:
+                rendered, hits = secret_registry.redact(rendered)
+                if hits:
+                    emit_event(
+                        SecurityEvent.now(
+                            kind=EventKind.SECRET_REDACTED,
+                            principal=egress_principal,
+                            detail={
+                                "direction": "egress",
+                                "role": m.role,
+                                "secrets": hits,
+                            },
+                        )
+                    )
+            outbound_messages.append({"role": m.role, "content": rendered})
+
         upstream_payload = {
             "model": req.model,
-            "messages": [
-                {"role": m.role, "content": _render_for_upstream(m, context)}
-                for m in req.messages
-            ],
+            "messages": outbound_messages,
         }
         with upstream_span(req.model):
             response = await upstream(upstream_payload)
+
+        if len(secret_registry) > 0:
+            _, ingress_hits = redact_nested(response, secret_registry)
+            if ingress_hits:
+                emit_event(
+                    SecurityEvent.now(
+                        kind=EventKind.SECRET_REDACTED,
+                        principal=egress_principal,
+                        detail={
+                            "direction": "ingress",
+                            "secrets": ingress_hits,
+                        },
+                    )
+                )
 
         proposed_calls = _extract_tool_calls(response)
         if not proposed_calls:

--- a/src/tessera/redaction.py
+++ b/src/tessera/redaction.py
@@ -1,0 +1,201 @@
+"""Credential isolation at the Tessera proxy boundary.
+
+The pattern this module implements is the GitHub Agent Workflow Firewall
+approach to credential handling: the proxy holds the real secret values,
+and any attempt to move those values across the proxy boundary (into a
+prompt the LLM will read, or back out in a model response the agent will
+read) is rewritten to an opaque marker before the bytes leave the proxy.
+
+In practice this looks like::
+
+    from tessera.proxy import create_app
+    from tessera.redaction import SecretRegistry
+
+    secrets = SecretRegistry()
+    secrets.add("GITHUB_TOKEN", os.environ["GITHUB_TOKEN"])
+    secrets.add("OPENAI_API_KEY", os.environ["OPENAI_API_KEY"])
+
+    app = create_app(key=hmac_key, upstream=upstream, secrets=secrets)
+
+The proxy will then scrub any occurrence of the registered values from
+both outbound chat-completion payloads and inbound responses, emitting a
+``SECRET_REDACTED`` security event whenever a hit fires. A compromised
+agent that tries to read ``os.environ["GITHUB_TOKEN"]`` and stuff the
+result into a chat prompt finds that the LLM only ever sees
+``<REDACTED:GITHUB_TOKEN>``.
+
+This is defense-in-depth. The right long-term answer is that the agent
+process should not hold the real values at all: it should hold
+placeholder tokens and the proxy substitutes on egress to downstream
+services. Reference architectures for that are tracked in the roadmap.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+# Values shorter than this are almost always going to cause false-positive
+# redactions on benign substrings ("123", "abc", short usernames). The
+# guard is a hard error at registration time rather than a silent loss of
+# signal at redaction time.
+_MIN_SECRET_LENGTH = 8
+
+
+@dataclass(frozen=True)
+class Secret:
+    """One named secret the proxy must never pass through to an LLM."""
+
+    name: str
+    value: str
+
+
+@dataclass
+class SecretRegistry:
+    """Ordered collection of secrets subject to redaction.
+
+    The registry is deliberately append-only through ``add`` so callers
+    cannot accidentally shadow an existing secret with a new one under
+    the same name or value. Clearing the registry is explicit (``clear``)
+    to make that operation audit-visible in code review.
+    """
+
+    _secrets: list[Secret] = field(default_factory=list)
+
+    def add(self, name: str, value: str) -> None:
+        """Register a secret for redaction.
+
+        Args:
+            name: Human-readable identifier used in the redaction marker
+                (for example ``GITHUB_TOKEN``). Must be non-empty.
+            value: The literal bytes that must not leave the proxy. Must
+                be at least 8 characters to avoid benign substring matches.
+
+        Raises:
+            ValueError: if ``name`` or ``value`` is empty, if ``value``
+                is shorter than 8 characters, or if either the name or
+                the value is already registered.
+        """
+        if not name:
+            raise ValueError("secret name must be non-empty")
+        if not value:
+            raise ValueError(f"secret value for {name!r} must be non-empty")
+        if len(value) < _MIN_SECRET_LENGTH:
+            raise ValueError(
+                f"refusing to register secret {name!r}: values under "
+                f"{_MIN_SECRET_LENGTH} characters are too likely to match "
+                "benign substrings and will cause false-positive redactions"
+            )
+        for existing in self._secrets:
+            if existing.name == name:
+                raise ValueError(f"secret {name!r} is already registered")
+            if existing.value == value:
+                raise ValueError(
+                    f"that value is already registered under the name "
+                    f"{existing.name!r}"
+                )
+        self._secrets.append(Secret(name=name, value=value))
+
+    def clear(self) -> None:
+        """Drop every registered secret. Intended for tests and shutdown."""
+        self._secrets.clear()
+
+    def __len__(self) -> int:
+        return len(self._secrets)
+
+    @property
+    def names(self) -> list[str]:
+        """Return the registered names in registration order."""
+        return [s.name for s in self._secrets]
+
+    @classmethod
+    def from_env(cls, *names: str) -> "SecretRegistry":
+        """Build a registry from current process environment variables.
+
+        Missing, empty, or too-short environment variables are skipped
+        silently so the same startup code can run in dev and in
+        production with different subsets of secrets available. Dev
+        environments sometimes set tokens to placeholders like
+        ``"dev"``; those are not worth registering.
+
+        Args:
+            *names: Environment variable names to register.
+
+        Returns:
+            A new SecretRegistry. Empty if none of the requested
+            variables were present or long enough.
+        """
+        reg = cls()
+        for var in names:
+            value = os.environ.get(var, "")
+            if value and len(value) >= _MIN_SECRET_LENGTH:
+                reg.add(var, value)
+        return reg
+
+    def redact(self, text: str) -> tuple[str, list[str]]:
+        """Replace every registered secret value in ``text`` with a marker.
+
+        The replacement marker is ``<REDACTED:NAME>`` where ``NAME`` is
+        the name the secret was registered under. Secrets are processed
+        in descending length order so a longer secret is replaced before
+        any shorter secret that might be its prefix.
+
+        Args:
+            text: The string to scrub. Non-string callers should route
+                through :func:`redact_nested` instead.
+
+        Returns:
+            A 2-tuple of ``(redacted_text, hit_names)``. ``hit_names`` is
+            the ordered list of secret names that matched at least once,
+            suitable for a security event detail field. Empty if the
+            text did not contain any registered secret.
+        """
+        if not self._secrets:
+            return text, []
+        hits: list[str] = []
+        ordered = sorted(self._secrets, key=lambda s: -len(s.value))
+        for secret in ordered:
+            if secret.value in text:
+                text = text.replace(secret.value, f"<REDACTED:{secret.name}>")
+                hits.append(secret.name)
+        return text, hits
+
+
+def redact_nested(obj, registry: SecretRegistry) -> tuple[object, list[str]]:
+    """Recursively redact secret values inside a JSON-shaped object.
+
+    Walks dicts and lists in place, rewriting string leaves that contain
+    a registered secret. Dict keys are left untouched on the assumption
+    that secrets appear in values, not in field names; a caller that
+    needs key-side redaction can do so explicitly.
+
+    Args:
+        obj: A dict, list, str, or primitive. Nested containers are
+            walked. Non-string leaves are left alone.
+        registry: The SecretRegistry to consult.
+
+    Returns:
+        A 2-tuple of ``(same_object_possibly_rewritten, all_hit_names)``.
+        The first element is the same reference that was passed in for
+        dicts and lists (mutation is in place) and a new string for
+        top-level string inputs.
+    """
+    all_hits: list[str] = []
+
+    def _walk(node):  # type: ignore[no-untyped-def]
+        if isinstance(node, str):
+            redacted, hits = registry.redact(node)
+            all_hits.extend(hits)
+            return redacted
+        if isinstance(node, dict):
+            for k, v in node.items():
+                node[k] = _walk(v)
+            return node
+        if isinstance(node, list):
+            for i, v in enumerate(node):
+                node[i] = _walk(v)
+            return node
+        return node
+
+    rewritten = _walk(obj)
+    return rewritten, all_hits

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -2,14 +2,29 @@
 
 from typing import Any
 
+import pytest
 from fastapi.testclient import TestClient
 
 from tessera.context import make_segment
+from tessera.events import (
+    EventKind,
+    SecurityEvent,
+    clear_sinks,
+    register_sink,
+)
 from tessera.labels import Origin, TrustLevel
 from tessera.policy import Policy
 from tessera.proxy import create_app
+from tessera.redaction import SecretRegistry
 
 KEY = b"test-hmac-key-do-not-use-in-prod"
+
+
+@pytest.fixture(autouse=True)
+def _reset_sinks():
+    clear_sinks()
+    yield
+    clear_sinks()
 
 
 def _always_calls_send_email(_: dict[str, Any]) -> dict[str, Any]:
@@ -110,3 +125,184 @@ def test_proxy_rejects_tampered_signature():
     }
     r = client.post("/v1/chat/completions", json=body)
     assert r.status_code == 401
+
+
+# Credential isolation: secrets registered with the proxy must never
+# appear in outbound payloads or inbound responses.
+
+
+_SECRET_TOKEN = "ghp_aaaaaaaa11111111bbbb"
+
+
+def _echo_upstream(captured: list[dict[str, Any]]):
+    async def call(payload: dict[str, Any]) -> dict[str, Any]:
+        captured.append(payload)
+        return {
+            "id": "stub",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "ok",
+                    }
+                }
+            ],
+        }
+
+    return call
+
+
+def _secret_echoing_upstream(_captured: list[dict[str, Any]]):
+    """Upstream that leaks the secret in both content and tool call args."""
+
+    async def call(payload: dict[str, Any]) -> dict[str, Any]:
+        del payload
+        return {
+            "id": "stub",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": f"here is the key: {_SECRET_TOKEN}",
+                        "tool_calls": [
+                            {
+                                "function": {
+                                    "name": "fetch_url",
+                                    "arguments": f'{{"auth": "{_SECRET_TOKEN}"}}',
+                                }
+                            }
+                        ],
+                    }
+                }
+            ],
+        }
+
+    return call
+
+
+def _client_with_secrets(upstream_factory) -> tuple[TestClient, list[dict[str, Any]]]:
+    captured: list[dict[str, Any]] = []
+    policy = Policy()
+    policy.require("send_email", TrustLevel.USER)
+    policy.require("fetch_url", TrustLevel.TOOL)
+    registry = SecretRegistry()
+    registry.add("GITHUB_TOKEN", _SECRET_TOKEN)
+    app = create_app(
+        key=KEY,
+        upstream=upstream_factory(captured),
+        policy=policy,
+        secrets=registry,
+    )
+    return TestClient(app), captured
+
+
+def test_proxy_redacts_secret_from_egress_payload():
+    """A secret accidentally included in a user message is scrubbed before upstream."""
+    events: list[SecurityEvent] = []
+    register_sink(events.append)
+
+    client, captured = _client_with_secrets(_echo_upstream)
+
+    # The user "accidentally" pastes their GITHUB_TOKEN into a prompt.
+    user_seg = make_segment(
+        f"please deploy with token {_SECRET_TOKEN}",
+        Origin.USER,
+        "alice",
+        KEY,
+    )
+    body = {
+        "model": "stub",
+        "messages": [_message_from(user_seg)],
+        "tools": [{"name": "send_email", "required_trust": int(TrustLevel.USER)}],
+    }
+    r = client.post("/v1/chat/completions", json=body)
+    assert r.status_code == 200
+
+    # Upstream must not have seen the raw token.
+    assert len(captured) == 1
+    upstream_text = captured[0]["messages"][0]["content"]
+    assert _SECRET_TOKEN not in upstream_text
+    assert "<REDACTED:GITHUB_TOKEN>" in upstream_text
+
+    # A SECRET_REDACTED event must have fired with direction=egress.
+    egress = [
+        e
+        for e in events
+        if e.kind == EventKind.SECRET_REDACTED
+        and e.detail.get("direction") == "egress"
+    ]
+    assert len(egress) == 1
+    assert egress[0].detail["secrets"] == ["GITHUB_TOKEN"]
+    assert egress[0].principal == "alice"
+
+
+def test_proxy_redacts_secret_from_ingress_response():
+    """A secret echoed by the upstream model never reaches the agent."""
+    events: list[SecurityEvent] = []
+    register_sink(events.append)
+
+    client, _ = _client_with_secrets(_secret_echoing_upstream)
+
+    user_seg = make_segment("tell me a joke", Origin.USER, "alice", KEY)
+    body = {
+        "model": "stub",
+        "messages": [_message_from(user_seg)],
+        "tools": [{"name": "fetch_url", "required_trust": int(TrustLevel.TOOL)}],
+    }
+    r = client.post("/v1/chat/completions", json=body)
+    assert r.status_code == 200
+    data = r.json()
+
+    # The response the agent sees must not contain the real token, in
+    # either the assistant content or the tool call arguments.
+    content = data["choices"][0]["message"]["content"]
+    tool_args = data["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"]
+    assert _SECRET_TOKEN not in content
+    assert _SECRET_TOKEN not in tool_args
+    assert "<REDACTED:GITHUB_TOKEN>" in content
+    assert "<REDACTED:GITHUB_TOKEN>" in tool_args
+
+    ingress = [
+        e
+        for e in events
+        if e.kind == EventKind.SECRET_REDACTED
+        and e.detail.get("direction") == "ingress"
+    ]
+    assert len(ingress) == 1
+    # The upstream leaks the secret twice (content + tool call args), so
+    # the hit list records two entries.
+    assert ingress[0].detail["secrets"].count("GITHUB_TOKEN") == 2
+
+
+def test_proxy_without_secrets_leaves_payload_untouched():
+    """The redaction path is a no-op when no secrets are registered."""
+    events: list[SecurityEvent] = []
+    register_sink(events.append)
+
+    captured: list[dict[str, Any]] = []
+    policy = Policy()
+    policy.require("send_email", TrustLevel.USER)
+    app = create_app(
+        key=KEY,
+        upstream=_echo_upstream(captured),
+        policy=policy,
+    )
+    client = TestClient(app)
+
+    user_seg = make_segment(
+        f"mention {_SECRET_TOKEN} here",
+        Origin.USER,
+        "alice",
+        KEY,
+    )
+    body = {
+        "model": "stub",
+        "messages": [_message_from(user_seg)],
+        "tools": [{"name": "send_email", "required_trust": int(TrustLevel.USER)}],
+    }
+    r = client.post("/v1/chat/completions", json=body)
+    assert r.status_code == 200
+
+    # No registry means no redaction and no SECRET_REDACTED events.
+    assert _SECRET_TOKEN in captured[0]["messages"][0]["content"]
+    assert not any(e.kind == EventKind.SECRET_REDACTED for e in events)

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,190 @@
+"""Unit tests for the SecretRegistry redaction primitive."""
+
+from __future__ import annotations
+
+import pytest
+
+from tessera.redaction import SecretRegistry, redact_nested
+
+
+def test_registry_add_and_redact_single_value():
+    reg = SecretRegistry()
+    reg.add("GITHUB_TOKEN", "ghp_abcdefghij1234567890")
+
+    redacted, hits = reg.redact(
+        "Here is my token ghp_abcdefghij1234567890 to use for cloning."
+    )
+
+    assert redacted == "Here is my token <REDACTED:GITHUB_TOKEN> to use for cloning."
+    assert hits == ["GITHUB_TOKEN"]
+
+
+def test_redact_returns_original_text_and_empty_hits_on_miss():
+    reg = SecretRegistry()
+    reg.add("GITHUB_TOKEN", "ghp_abcdefghij1234567890")
+
+    redacted, hits = reg.redact("nothing sensitive here")
+
+    assert redacted == "nothing sensitive here"
+    assert hits == []
+
+
+def test_registry_is_noop_when_empty():
+    reg = SecretRegistry()
+    redacted, hits = reg.redact("arbitrary text ghp_fake")
+    assert redacted == "arbitrary text ghp_fake"
+    assert hits == []
+
+
+def test_duplicate_name_rejected():
+    reg = SecretRegistry()
+    reg.add("TOKEN", "value-one-long-enough")
+    with pytest.raises(ValueError, match="already registered"):
+        reg.add("TOKEN", "value-two-different-but-same-name")
+
+
+def test_duplicate_value_rejected_even_under_different_name():
+    reg = SecretRegistry()
+    reg.add("TOKEN_A", "shared-value-long-enough")
+    with pytest.raises(ValueError, match="already registered under"):
+        reg.add("TOKEN_B", "shared-value-long-enough")
+
+
+def test_short_secret_rejected_to_avoid_false_positives():
+    reg = SecretRegistry()
+    with pytest.raises(ValueError, match="too likely to match"):
+        reg.add("PIN", "1234")
+
+
+def test_empty_name_rejected():
+    reg = SecretRegistry()
+    with pytest.raises(ValueError, match="name must be non-empty"):
+        reg.add("", "value-long-enough")
+
+
+def test_empty_value_rejected():
+    reg = SecretRegistry()
+    with pytest.raises(ValueError, match="must be non-empty"):
+        reg.add("TOKEN", "")
+
+
+def test_longer_secret_replaced_before_its_prefix():
+    """A longer secret that contains a shorter secret must be replaced first.
+
+    Otherwise the shorter secret would chop the longer one into pieces
+    and the longer marker would never fire. The registry sorts by
+    descending length at redaction time to prevent this.
+    """
+    reg = SecretRegistry()
+    reg.add("SHORT_TOKEN", "abcdefgh")  # 8 chars, minimum
+    reg.add("LONG_TOKEN", "abcdefghij1234567890")  # contains SHORT_TOKEN as prefix
+
+    redacted, hits = reg.redact("see abcdefghij1234567890 for details")
+
+    assert redacted == "see <REDACTED:LONG_TOKEN> for details"
+    assert hits == ["LONG_TOKEN"]
+
+
+def test_multiple_secrets_in_one_string_all_redacted():
+    reg = SecretRegistry()
+    reg.add("A", "aaaa1111bbbb")
+    reg.add("B", "cccc2222dddd")
+
+    redacted, hits = reg.redact("A=aaaa1111bbbb B=cccc2222dddd end")
+
+    assert "aaaa1111bbbb" not in redacted
+    assert "cccc2222dddd" not in redacted
+    assert "<REDACTED:A>" in redacted
+    assert "<REDACTED:B>" in redacted
+    assert set(hits) == {"A", "B"}
+
+
+def test_names_property_preserves_registration_order():
+    reg = SecretRegistry()
+    reg.add("FIRST", "aaaaaaaa1")
+    reg.add("SECOND", "bbbbbbbb2")
+    reg.add("THIRD", "cccccccc3")
+    assert reg.names == ["FIRST", "SECOND", "THIRD"]
+
+
+def test_len_reflects_registered_count():
+    reg = SecretRegistry()
+    assert len(reg) == 0
+    reg.add("A", "aaaaaaaa1")
+    assert len(reg) == 1
+    reg.add("B", "bbbbbbbb2")
+    assert len(reg) == 2
+
+
+def test_clear_drops_all_secrets():
+    reg = SecretRegistry()
+    reg.add("A", "aaaaaaaa1")
+    reg.add("B", "bbbbbbbb2")
+    reg.clear()
+    assert len(reg) == 0
+    redacted, hits = reg.redact("aaaaaaaa1 and bbbbbbbb2")
+    assert redacted == "aaaaaaaa1 and bbbbbbbb2"
+    assert hits == []
+
+
+def test_from_env_skips_missing_and_short_values(monkeypatch):
+    monkeypatch.setenv("TESSERA_REAL", "real-token-long-enough")
+    monkeypatch.setenv("TESSERA_SHORT", "dev")
+    monkeypatch.delenv("TESSERA_MISSING", raising=False)
+
+    reg = SecretRegistry.from_env("TESSERA_REAL", "TESSERA_SHORT", "TESSERA_MISSING")
+
+    assert reg.names == ["TESSERA_REAL"]
+
+
+def test_redact_nested_walks_dicts_and_lists():
+    reg = SecretRegistry()
+    reg.add("TOKEN", "ghp_aaaaaaaa11111111")
+
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": "leaked: ghp_aaaaaaaa11111111",
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "send",
+                                "arguments": '{"key": "ghp_aaaaaaaa11111111"}',
+                            }
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+    _, hits = redact_nested(payload, reg)
+
+    assert hits.count("TOKEN") == 2
+    assert "ghp_aaaaaaaa11111111" not in payload["choices"][0]["message"]["content"]
+    assert "<REDACTED:TOKEN>" in payload["choices"][0]["message"]["content"]
+    tool_args = payload["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"]
+    assert "ghp_aaaaaaaa11111111" not in tool_args
+    assert "<REDACTED:TOKEN>" in tool_args
+
+
+def test_redact_nested_leaves_non_string_leaves_alone():
+    reg = SecretRegistry()
+    reg.add("TOKEN", "ghp_aaaaaaaa11111111")
+
+    payload = {
+        "count": 42,
+        "ratio": 3.14,
+        "enabled": True,
+        "nothing": None,
+        "text": "ghp_aaaaaaaa11111111 leaked",
+    }
+
+    _, hits = redact_nested(payload, reg)
+
+    assert payload["count"] == 42
+    assert payload["ratio"] == 3.14
+    assert payload["enabled"] is True
+    assert payload["nothing"] is None
+    assert hits == ["TOKEN"]


### PR DESCRIPTION
ROADMAP item 2. Closes two real attack classes at the proxy boundary: an agent that accidentally (or under injection) pastes a real credential into an LLM prompt, and an LLM response that echoes a registered secret back to the caller.

### Description of change

New module `tessera.redaction` plus proxy integration. The proxy now accepts an optional `SecretRegistry` at `create_app()` time. When one is provided:

- **Egress:** each inbound message's rendered content is scrubbed before the outbound payload is handed to the upstream LLM. Hits emit `SECRET_REDACTED` with `direction=egress`.
- **Ingress:** the full upstream response is walked recursively via `redact_nested`. String leaves containing a registered value are rewritten in place. Hits emit `SECRET_REDACTED` with `direction=ingress`. This catches assistant content, tool call arguments, and any other string fields.

Both paths are complete no-ops when the registry is empty, so existing deployments see zero behavior change.

The registry itself:

- `Secret` and `SecretRegistry` dataclasses. Append-only through `add()` to make shadowing audit-visible.
- `add()` rejects empty names, empty values, duplicates by name or value, and values under 8 characters (benign-substring false-positive guard is a hard error, not a silent loss of signal).
- `redact(text)` replaces registered values with `<REDACTED:NAME>`, sorted descending by length so a long secret wins over any shorter secret that might be its prefix. The test `test_longer_secret_replaced_before_its_prefix` pins this.
- `redact_nested(obj, registry)` walks dicts and lists in place and rewrites string leaves.
- `from_env(*names)` loader skips missing or too-short env vars silently so the same startup code runs in dev and prod.

New enum value `EventKind.SECRET_REDACTED`. Every redaction event carries `direction`, the principal from the context, and the list of hit names. Allow/deny silence semantics are preserved for the rest of the event stream; this is a new low-volume signal on top.

### How tested

- 16 new unit tests in `tests/test_redaction.py` covering: happy path redaction, miss path, empty registry no-op, duplicate name / duplicate value rejection, short-secret rejection, empty name/value rejection, long-secret-over-short-prefix ordering, multiple secrets in one string, `names` ordering, `len()`, `clear()`, `from_env` behavior, `redact_nested` on nested dicts/lists and non-string leaves.
- 3 new proxy integration tests in `tests/test_proxy.py`: egress redaction + egress event, ingress redaction (content + tool call args) + ingress event, and the unregistered no-op path. All use a new `_secret_echoing_upstream` stub that deliberately leaks the secret in two places.
- Full suite: 84 passing, ~1.5s runtime. Up from 65 baseline; 16 redaction unit tests, 3 proxy integration tests.

### Module-naming note

The obvious name for this module was `tessera.secrets`, but the user's Claude Code deny rules include `Write(**/secrets.*)` to block accidentally committed `.env` / `secrets.json` files. That caught my Python module by mistake. `tessera.redaction` is actually a better name: it describes the operation the module performs rather than its inputs, and it avoids a footgun where grepping for "secrets" in the repo surfaces source files next to real secret-handling code review targets.

### Docs

- `docs/ARCHITECTURE.md`: new `redaction.py` module section, updated module-map listing, and a paragraph in `proxy.py` explaining the integration.
- `docs/ROADMAP.md` item 2: updated to reflect what has landed (ingress/egress text redaction) and what remains open (downstream-tool substitute-on-egress, which requires the proxy to mediate tool traffic beyond just chat completions).

### Not in scope

- cli.py still does not wire secrets automatically from the environment. Adding a `--secret NAME=VAR` flag or a JSON config would be a 20-line follow-up, but it felt like scope creep for a PR that already introduces a module and modifies the proxy.
- The long-term pattern (agent holds placeholder tokens, proxy substitutes on egress to downstream services) is not built here. That requires the proxy to mediate tool traffic. Tracked in the updated ROADMAP entry.
- CHANGELOG is intentionally not touched in this PR for the same reason as PR #3: the v0.0.1 section is historical, and the Unreleased section lives on the benchmark PR branch.