### PR TITLE
proxy-credential-isolation

### DIFF
--- a/proto/tessera/hooks/v1/hooks.proto
+++ b/proto/tessera/hooks/v1/hooks.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+package tessera.hooks.v1;
+
+message PostPolicyEvaluateRequest {
+    string tool = 1;
+    string principal = 2;
+    string decision_kind = 3;
+    string reason = 4;
+    int32 required_trust = 5;
+    int32 observed_trust = 6;
+}
+
+message PostPolicyEvaluateResponse {
+    string decision_kind = 1;  // can only change ALLOW to DENY
+    string reason = 2;
+}
+
+message PostToolCallGateRequest {
+    string tool = 1;
+    string arguments_json = 2;
+    string principal = 3;
+}
+
+message PostToolCallGateResponse {
+    bool allow = 1;
+    string reason = 2;
+}
+
+message PostDelegationVerifyRequest {
+    string subject = 1;
+    string delegate = 2;
+    string audience = 3;
+    repeated string authorized_actions = 4;
+}
+
+message PostDelegationVerifyResponse {
+    bool valid = 1;
+    string reason = 2;
+}

--- a/proto/tessera/xds/v1/discovery.proto
+++ b/proto/tessera/xds/v1/discovery.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+package tessera.xds.v1;
+
+import "proto/tessera/xds/v1/resources.proto";
+
+message DiscoveryRequest {
+    string node_id = 1;
+    string resource_type = 2;
+    string version_info = 3;
+    repeated string resource_names = 4;
+}
+
+message DiscoveryResponse {
+    string version_info = 1;
+    string type_url = 2;
+    repeated ResourceWrapper resources = 3;
+    string nonce = 4;
+}
+
+message ResourceWrapper {
+    string name = 1;
+    string version = 2;
+    bytes resource = 3;  // serialized PolicyBundle, ToolRegistry, or TrustConfig
+}
+
+service AggregatedDiscoveryService {
+    rpc StreamResources(stream DiscoveryRequest) returns (stream DiscoveryResponse);
+    rpc FetchResources(DiscoveryRequest) returns (DiscoveryResponse);
+}

--- a/proto/tessera/xds/v1/resources.proto
+++ b/proto/tessera/xds/v1/resources.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+package tessera.xds.v1;
+
+message PolicyBundle {
+    string version = 1;
+    string revision = 2;
+    repeated ToolRequirement requirements = 3;
+    int32 default_trust_level = 4;
+    repeated string human_approval_tools = 5;
+}
+
+message ToolRequirement {
+    string name = 1;
+    string resource_type = 2;
+    int32 required_trust = 3;
+}
+
+message ToolRegistryEntry {
+    string name = 1;
+    bool is_external = 2;
+}
+
+message ToolRegistry {
+    string version = 1;
+    string revision = 2;
+    repeated ToolRegistryEntry tools = 3;
+}
+
+message TrustConfig {
+    string version = 1;
+    string revision = 2;
+    map<string, int32> trust_levels = 3;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,15 @@ spiffe = [
 mcp = [
     "mcp>=1.0",
 ]
+cel = [
+    "cel-python>=0.1",
+]
 agentmesh = [
     "pyyaml>=6.0",
+]
+xds = [
+    "grpcio>=1.60",
+    "protobuf>=4.25",
 ]
 
 [project.scripts]

--- a/rust/tessera-gateway/Cargo.lock
+++ b/rust/tessera-gateway/Cargo.lock
@@ -1264,6 +1264,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,6 +1468,7 @@ dependencies = [
 name = "tessera-gateway"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "base64",
  "chrono",
@@ -1467,6 +1477,7 @@ dependencies = [
  "jsonwebtoken",
  "reqwest",
  "rustls",
+ "secrecy",
  "serde",
  "serde_json",
  "sha2",

--- a/rust/tessera-gateway/Cargo.toml
+++ b/rust/tessera-gateway/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+async-trait = "0.1"
 axum = { version = "0.8", features = ["json", "macros"] }
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
@@ -12,6 +13,7 @@ hex = "0.4"
 hmac = "0.12"
 jsonwebtoken = "9"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+secrecy = "0.8"
 rustls = { version = "0.23", features = ["ring"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/tessera-gateway/src/filters/identity_verification.rs
+++ b/rust/tessera-gateway/src/filters/identity_verification.rs
@@ -1,0 +1,78 @@
+use async_trait::async_trait;
+
+use super::{Filter, FilterResult, RequestContext};
+use crate::{
+    request_url, verify_delegation_header, verify_identity_headers, verify_prompt_provenance,
+    verify_transport_identity,
+};
+
+/// Verifies transport identity, workload identity (JWT+PoP),
+/// delegation tokens, and prompt provenance headers.
+pub struct IdentityVerificationFilter;
+
+#[async_trait]
+impl Filter for IdentityVerificationFilter {
+    async fn on_request(&self, ctx: &mut RequestContext) -> FilterResult {
+        let identity_header = ctx
+            .headers
+            .get("ASM-Agent-Identity")
+            .and_then(|v| v.to_str().ok());
+        let proof_header = ctx
+            .headers
+            .get("ASM-Agent-Proof")
+            .and_then(|v| v.to_str().ok());
+        let delegation_header = ctx
+            .headers
+            .get("ASM-Agent-Delegation")
+            .and_then(|v| v.to_str().ok());
+
+        let peer_identity = match verify_transport_identity(
+            &ctx.state.config,
+            ctx.headers
+                .get("x-forwarded-client-cert")
+                .and_then(|v| v.to_str().ok()),
+            ctx.immediate_client_host.clone(),
+            ctx.transport_identity.clone(),
+            ctx.transport_error.clone(),
+        ) {
+            Ok(identity) => identity,
+            Err(response) => return FilterResult::ShortCircuit(response),
+        };
+
+        let verified_identity = match verify_identity_headers(
+            identity_header,
+            proof_header,
+            &ctx.state.config,
+            &ctx.method,
+            &request_url(&ctx.headers, &ctx.uri),
+            &ctx.state.proof_replay_cache,
+            peer_identity.as_ref(),
+        ) {
+            Ok(identity) => identity,
+            Err(response) => return FilterResult::ShortCircuit(response),
+        };
+
+        let delegation = match verify_delegation_header(delegation_header, &ctx.state.config) {
+            Ok(token) => token,
+            Err(response) => return FilterResult::ShortCircuit(response),
+        };
+
+        let provenance_header = ctx
+            .headers
+            .get("ASM-Prompt-Provenance")
+            .and_then(|v| v.to_str().ok());
+        if let Err(response) = verify_prompt_provenance(
+            provenance_header,
+            &ctx.request.messages,
+            ctx.state.config.provenance_key(),
+        ) {
+            return FilterResult::ShortCircuit(response);
+        }
+
+        ctx.peer_identity = peer_identity;
+        ctx.verified_identity = verified_identity;
+        ctx.delegation = delegation;
+        ctx.provenance_verified = provenance_header.is_some();
+        FilterResult::Continue
+    }
+}

--- a/rust/tessera-gateway/src/filters/label_verification.rs
+++ b/rust/tessera-gateway/src/filters/label_verification.rs
@@ -1,0 +1,35 @@
+use async_trait::async_trait;
+
+use super::{Filter, FilterResult, RequestContext};
+use crate::{not_implemented, validate_declared_tools, verify_labels};
+
+/// Verifies HMAC signatures on all message labels and validates
+/// the declared tool surface before passing to downstream filters.
+pub struct LabelVerificationFilter;
+
+#[async_trait]
+impl Filter for LabelVerificationFilter {
+    async fn on_request(&self, ctx: &mut RequestContext) -> FilterResult {
+        if !ctx.state.config.chat_enforcement_enabled() {
+            return FilterResult::ShortCircuit(not_implemented(
+                "Rust gateway scaffold exists, chat mediation is not implemented yet",
+            ));
+        }
+        let label_key = match ctx.state.config.label_hmac_key.as_ref() {
+            Some(key) => key.as_slice(),
+            None => {
+                return FilterResult::ShortCircuit(not_implemented(
+                    "Rust gateway scaffold exists, chat mediation is not implemented yet",
+                ))
+            }
+        };
+
+        if let Err(response) = verify_labels(&ctx.request.messages, label_key) {
+            return FilterResult::ShortCircuit(response);
+        }
+        if let Err(response) = validate_declared_tools(&ctx.request.tools) {
+            return FilterResult::ShortCircuit(response);
+        }
+        FilterResult::Continue
+    }
+}

--- a/rust/tessera-gateway/src/filters/mod.rs
+++ b/rust/tessera-gateway/src/filters/mod.rs
@@ -1,0 +1,98 @@
+//! Composable filter pipeline for the Tessera gateway.
+//!
+//! Modeled on agentgateway's filter architecture. Each filter can
+//! inspect and modify the request context, or short-circuit with
+//! a direct response.
+
+use async_trait::async_trait;
+use axum::response::Response;
+use std::sync::Arc;
+
+pub mod identity_verification;
+pub mod label_verification;
+pub mod policy_evaluation;
+pub mod upstream;
+
+use crate::{
+    AppState, ChatRequest, DelegationHeaderModel, GatewayConfig, RuntimeControlState,
+    TransportPeerIdentity, VerifiedIdentity,
+};
+
+/// Context shared across all filters in the pipeline for one request.
+pub struct RequestContext {
+    pub request: ChatRequest,
+    pub state: AppState,
+    pub headers: axum::http::HeaderMap,
+    pub method: axum::http::Method,
+    pub uri: axum::http::Uri,
+    pub immediate_client_host: Option<String>,
+    pub transport_identity: Option<TransportPeerIdentity>,
+    pub transport_error: Option<String>,
+    pub verified_identity: Option<VerifiedIdentity>,
+    pub peer_identity: Option<TransportPeerIdentity>,
+    pub delegation: Option<DelegationHeaderModel>,
+    pub provenance_verified: bool,
+    pub runtime: Option<RuntimeControlState>,
+    pub rendered_messages: Vec<serde_json::Value>,
+    pub upstream_payload: Option<serde_json::Value>,
+}
+
+/// Result of a filter execution.
+pub enum FilterResult {
+    /// Continue to the next filter.
+    Continue,
+    /// Short-circuit the pipeline with a direct response.
+    ShortCircuit(Response),
+}
+
+/// A composable request/response filter.
+#[async_trait]
+pub trait Filter: Send + Sync {
+    /// Process the inbound request. Return Continue to pass to next
+    /// filter, or ShortCircuit to respond immediately.
+    async fn on_request(&self, ctx: &mut RequestContext) -> FilterResult;
+
+    /// Process the outbound response. Default is passthrough.
+    async fn on_response(
+        &self,
+        ctx: &mut RequestContext,
+        response: &mut serde_json::Value,
+    ) -> FilterResult {
+        let _ = ctx;
+        let _ = response;
+        FilterResult::Continue
+    }
+}
+
+/// Ordered list of filters executed in sequence.
+pub struct FilterChain {
+    filters: Vec<Box<dyn Filter>>,
+}
+
+impl FilterChain {
+    pub fn new(filters: Vec<Box<dyn Filter>>) -> Self {
+        Self { filters }
+    }
+
+    pub async fn execute_request(&self, ctx: &mut RequestContext) -> Option<Response> {
+        for filter in &self.filters {
+            match filter.on_request(ctx).await {
+                FilterResult::Continue => continue,
+                FilterResult::ShortCircuit(response) => return Some(response),
+            }
+        }
+        None
+    }
+
+    pub async fn execute_response(
+        &self,
+        ctx: &mut RequestContext,
+        response: &mut serde_json::Value,
+    ) {
+        for filter in &self.filters {
+            if let FilterResult::ShortCircuit(_) = filter.on_response(ctx, response).await {
+                break;
+            }
+        }
+    }
+}

--- a/rust/tessera-gateway/src/filters/policy_evaluation.rs
+++ b/rust/tessera-gateway/src/filters/policy_evaluation.rs
@@ -1,0 +1,52 @@
+use async_trait::async_trait;
+use serde_json::json;
+
+use super::{Filter, FilterResult, RequestContext};
+use crate::{
+    echo_response, evaluate_call_outcome, extract_tool_calls, min_trust, render_for_upstream,
+    Decision,
+};
+
+/// Renders messages for upstream, evaluates tool calls against
+/// trust policy, and produces the final annotated response.
+///
+/// If upstream forwarding is disabled, returns an echo response
+/// containing the rendered messages.
+pub struct PolicyEvaluationFilter;
+
+#[async_trait]
+impl Filter for PolicyEvaluationFilter {
+    async fn on_request(&self, ctx: &mut RequestContext) -> FilterResult {
+        let runtime = ctx.state.runtime_control.read().await.clone();
+        ctx.runtime = Some(runtime);
+
+        let rendered_messages: Vec<serde_json::Value> = ctx
+            .request
+            .messages
+            .iter()
+            .map(|message| {
+                json!({
+                    "role": message.role,
+                    "content": render_for_upstream(message),
+                })
+            })
+            .collect();
+        let upstream_payload = json!({
+            "model": ctx.request.model,
+            "messages": rendered_messages,
+        });
+
+        ctx.rendered_messages = rendered_messages;
+        ctx.upstream_payload = Some(upstream_payload);
+
+        if !ctx.state.config.chat_forwarding_enabled() {
+            return FilterResult::ShortCircuit(echo_response(
+                ctx.request.model.clone(),
+                ctx.rendered_messages.clone(),
+                ctx.provenance_verified,
+            ));
+        }
+
+        FilterResult::Continue
+    }
+}

--- a/rust/tessera-gateway/src/filters/upstream.rs
+++ b/rust/tessera-gateway/src/filters/upstream.rs
@@ -1,0 +1,122 @@
+use async_trait::async_trait;
+use axum::{response::IntoResponse, Json};
+use serde_json::json;
+
+use super::{Filter, FilterResult, RequestContext};
+use crate::{
+    echo_response, error_response, evaluate_call_outcome, extract_tool_calls, forward_upstream,
+    min_trust, Decision, StatusCode,
+};
+
+/// Forwards the request to the upstream LLM, evaluates proposed
+/// tool calls against the trust policy, and annotates the response
+/// with allow/deny verdicts.
+pub struct UpstreamFilter;
+
+#[async_trait]
+impl Filter for UpstreamFilter {
+    async fn on_request(&self, ctx: &mut RequestContext) -> FilterResult {
+        let upstream_url = match &ctx.state.config.upstream_url {
+            Some(value) => value.clone(),
+            None => {
+                return FilterResult::ShortCircuit(echo_response(
+                    ctx.request.model.clone(),
+                    ctx.rendered_messages.clone(),
+                    ctx.provenance_verified,
+                ))
+            }
+        };
+        let client = match &ctx.state.client {
+            Some(value) => value,
+            None => {
+                return FilterResult::ShortCircuit(error_response(
+                    StatusCode::BAD_GATEWAY,
+                    "upstream forwarding is configured but no HTTP client is available",
+                ))
+            }
+        };
+
+        let upstream_payload = match &ctx.upstream_payload {
+            Some(payload) => payload.clone(),
+            None => {
+                return FilterResult::ShortCircuit(error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "upstream payload was not prepared by prior filter",
+                ))
+            }
+        };
+
+        let mut upstream_response = match forward_upstream(client, &upstream_url, &upstream_payload).await
+        {
+            Ok(response) => response,
+            Err(response) => return FilterResult::ShortCircuit(response),
+        };
+
+        let proposed_calls = extract_tool_calls(&upstream_response.body);
+        if proposed_calls.is_empty() {
+            return FilterResult::ShortCircuit(
+                (upstream_response.status, Json(upstream_response.body)).into_response(),
+            );
+        }
+
+        let observed_trust = min_trust(&ctx.request.messages);
+        let runtime = ctx
+            .runtime
+            .as_ref()
+            .expect("runtime must be populated by PolicyEvaluationFilter");
+        let mut allowed = Vec::new();
+        let mut denied = Vec::new();
+        for call in &proposed_calls {
+            let outcome = evaluate_call_outcome(
+                &ctx.state,
+                &ctx.request,
+                call,
+                observed_trust,
+                ctx.delegation.as_ref(),
+                runtime,
+            )
+            .await;
+            match outcome.decision {
+                Decision::Allow => {
+                    allowed.push(json!({
+                        "name": call.name,
+                        "arguments": call.arguments,
+                    }));
+                }
+                Decision::Deny {
+                    reason,
+                    required_trust,
+                    observed_trust,
+                } => {
+                    denied.push(json!({
+                        "tool": call.name,
+                        "denied": true,
+                        "reason": reason,
+                        "required_trust": required_trust,
+                        "observed_trust": observed_trust,
+                        "backend": outcome.backend,
+                        "backend_metadata": outcome.backend_metadata,
+                    }));
+                }
+            }
+        }
+
+        let response = match upstream_response.body.as_object_mut() {
+            Some(body) => {
+                body.insert(
+                    "tessera".to_string(),
+                    json!({
+                        "allowed": allowed,
+                        "denied": denied,
+                    }),
+                );
+                (upstream_response.status, Json(upstream_response.body)).into_response()
+            }
+            None => error_response(
+                StatusCode::BAD_GATEWAY,
+                "upstream response must be a JSON object",
+            ),
+        };
+        FilterResult::ShortCircuit(response)
+    }
+}

--- a/rust/tessera-gateway/src/lib.rs
+++ b/rust/tessera-gateway/src/lib.rs
@@ -13,6 +13,8 @@ use std::{
     time::Duration,
 };
 
+pub mod filters;
+
 use axum::{
     extract::connect_info::Connected,
     extract::{connect_info::ConnectInfo, Extension, OriginalUri, Request, State},
@@ -30,6 +32,7 @@ use jsonwebtoken::{
     EncodingKey, Header, Validation,
 };
 use reqwest::Client;
+use secrecy::{ExposeSecret, Secret};
 use rustls::{
     pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer},
     server::WebPkiClientVerifier,
@@ -699,6 +702,90 @@ impl GatewayConfig {
             .map(|(trust_domain, _)| vec![trust_domain])
             .unwrap_or_default()
     }
+
+    /// Returns the label HMAC key wrapped in a Secret to prevent
+    /// accidental logging or serialization.
+    pub fn label_hmac_secret(&self) -> Option<Secret<Vec<u8>>> {
+        self.label_hmac_key.as_ref().map(|k| Secret::new(k.clone()))
+    }
+
+    /// Returns the identity HS256 key wrapped in a Secret.
+    pub fn identity_hs256_secret(&self) -> Option<Secret<Vec<u8>>> {
+        self.identity_hs256_key
+            .as_ref()
+            .map(|k| Secret::new(k.clone()))
+    }
+
+    /// Returns the delegation key wrapped in a Secret, falling back
+    /// to the label HMAC key.
+    pub fn delegation_secret(&self) -> Option<Secret<Vec<u8>>> {
+        self.delegation_key
+            .as_ref()
+            .or(self.label_hmac_key.as_ref())
+            .map(|k| Secret::new(k.clone()))
+    }
+
+    /// Returns the control-plane HMAC key wrapped in a Secret.
+    pub fn control_plane_hmac_secret(&self) -> Option<Secret<Vec<u8>>> {
+        self.control_plane_hmac_key
+            .as_ref()
+            .map(|k| Secret::new(k.clone()))
+    }
+}
+
+/// Watches a file path and reloads the secret when it changes.
+/// Designed for credential rotation without gateway restarts.
+pub struct SecretWatcher {
+    path: std::path::PathBuf,
+    last_modified: std::sync::Mutex<Option<std::time::SystemTime>>,
+    current: std::sync::RwLock<Secret<Vec<u8>>>,
+}
+
+impl SecretWatcher {
+    pub fn new(path: impl Into<std::path::PathBuf>, initial: Vec<u8>) -> Self {
+        let path = path.into();
+        let mtime = std::fs::metadata(&path)
+            .and_then(|m| m.modified())
+            .ok();
+        Self {
+            path,
+            last_modified: std::sync::Mutex::new(mtime),
+            current: std::sync::RwLock::new(Secret::new(initial)),
+        }
+    }
+
+    /// Checks whether the watched file has been modified since the
+    /// last load. If so, reads the new contents and returns true.
+    pub fn check_reload(&self) -> bool {
+        let mtime = match std::fs::metadata(&self.path).and_then(|m| m.modified()) {
+            Ok(t) => t,
+            Err(_) => return false,
+        };
+        let mut last = match self.last_modified.lock() {
+            Ok(guard) => guard,
+            Err(_) => return false,
+        };
+        if *last == Some(mtime) {
+            return false;
+        }
+        let bytes = match std::fs::read(&self.path) {
+            Ok(b) => b,
+            Err(_) => return false,
+        };
+        if let Ok(mut w) = self.current.write() {
+            *w = Secret::new(bytes);
+        }
+        *last = Some(mtime);
+        true
+    }
+
+    /// Returns a clone of the current secret value.
+    pub fn current(&self) -> Secret<Vec<u8>> {
+        self.current
+            .read()
+            .map(|guard| Secret::new(guard.expose_secret().clone()))
+            .unwrap_or_else(|_| Secret::new(Vec::new()))
+    }
 }
 
 #[derive(Clone)]
@@ -710,7 +797,7 @@ pub struct AppState {
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
-struct RuntimeControlState {
+pub(crate) struct RuntimeControlState {
     configured: bool,
     ready: bool,
     policy: ManagedPolicyState,
@@ -810,11 +897,11 @@ pub struct GatewayConnectInfo {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-struct ChatRequest {
-    model: String,
-    messages: Vec<MessageModel>,
+pub(crate) struct ChatRequest {
+    pub(crate) model: String,
+    pub(crate) messages: Vec<MessageModel>,
     #[serde(default)]
-    tools: Vec<ToolModel>,
+    pub(crate) tools: Vec<ToolModel>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -844,32 +931,32 @@ struct A2AInputSegmentModel {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-struct MessageModel {
-    role: String,
-    content: String,
-    label: LabelModel,
+pub(crate) struct MessageModel {
+    pub(crate) role: String,
+    pub(crate) content: String,
+    pub(crate) label: LabelModel,
 }
 
 #[derive(Clone, Debug, Deserialize)]
-struct LabelModel {
-    origin: String,
-    principal: String,
-    trust_level: i64,
-    nonce: String,
-    signature: String,
+pub(crate) struct LabelModel {
+    pub(crate) origin: String,
+    pub(crate) principal: String,
+    pub(crate) trust_level: i64,
+    pub(crate) nonce: String,
+    pub(crate) signature: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]
-struct ToolModel {
-    name: String,
+pub(crate) struct ToolModel {
+    pub(crate) name: String,
     #[serde(default = "default_required_trust")]
-    required_trust: i64,
+    pub(crate) required_trust: i64,
 }
 
 #[derive(Clone, Debug)]
-struct ProposedCall {
-    name: String,
-    arguments: Option<Value>,
+pub(crate) struct ProposedCall {
+    pub(crate) name: String,
+    pub(crate) arguments: Option<Value>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -926,9 +1013,9 @@ struct VerifiedA2ASecurityContext {
 }
 
 #[derive(Clone, Debug)]
-struct UpstreamResponse {
-    status: StatusCode,
-    body: Value,
+pub(crate) struct UpstreamResponse {
+    pub(crate) status: StatusCode,
+    pub(crate) body: Value,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -978,7 +1065,7 @@ struct PolicyBackendDecision {
 }
 
 #[derive(Clone, Debug)]
-enum Decision {
+pub(crate) enum Decision {
     Allow,
     Deny {
         reason: String,
@@ -988,10 +1075,10 @@ enum Decision {
 }
 
 #[derive(Clone, Debug)]
-struct DecisionOutcome {
-    decision: Decision,
-    backend: Option<String>,
-    backend_metadata: Value,
+pub(crate) struct DecisionOutcome {
+    pub(crate) decision: Decision,
+    pub(crate) backend: Option<String>,
+    pub(crate) backend_metadata: Value,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1025,24 +1112,24 @@ struct ConfirmationClaim {
 }
 
 #[derive(Clone, Debug)]
-struct VerifiedIdentity {
-    agent_id: String,
-    key_binding: Option<String>,
+pub(crate) struct VerifiedIdentity {
+    pub(crate) agent_id: String,
+    pub(crate) key_binding: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct DelegationHeaderModel {
-    subject: String,
-    delegate: String,
-    audience: String,
+pub(crate) struct DelegationHeaderModel {
+    pub(crate) subject: String,
+    pub(crate) delegate: String,
+    pub(crate) audience: String,
     #[serde(default)]
-    authorized_actions: Vec<String>,
+    pub(crate) authorized_actions: Vec<String>,
     #[serde(default = "default_object")]
-    constraints: Value,
+    pub(crate) constraints: Value,
     #[serde(default)]
-    session_id: String,
-    expires_at: String,
-    signature: String,
+    pub(crate) session_id: String,
+    pub(crate) expires_at: String,
+    pub(crate) signature: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2137,7 +2224,7 @@ pub fn spawn_control_plane_sync_loop(state: AppState) {
     });
 }
 
-fn verify_labels(messages: &[MessageModel], key: &[u8]) -> Result<(), Response> {
+pub(crate) fn verify_labels(messages: &[MessageModel], key: &[u8]) -> Result<(), Response> {
     for message in messages {
         if !is_valid_origin(&message.label.origin)
             || !is_valid_trust_level(message.label.trust_level)
@@ -2166,7 +2253,7 @@ fn verify_labels(messages: &[MessageModel], key: &[u8]) -> Result<(), Response> 
     Ok(())
 }
 
-fn validate_declared_tools(tools: &[ToolModel]) -> Result<(), Response> {
+pub(crate) fn validate_declared_tools(tools: &[ToolModel]) -> Result<(), Response> {
     for tool in tools {
         if tool.name.trim().is_empty() || !is_valid_trust_level(tool.required_trust) {
             return Err(error_response(
@@ -2483,7 +2570,7 @@ fn ordered_a2a_envelopes(
     Ok(ordered)
 }
 
-fn verify_identity_headers(
+pub(crate) fn verify_identity_headers(
     identity_header: Option<&str>,
     proof_header: Option<&str>,
     config: &GatewayConfig,

--- a/src/tessera/__init__.py
+++ b/src/tessera/__init__.py
@@ -47,6 +47,12 @@ from tessera.events import (
     unregister_sink,
     webhook_sink,
 )
+from tessera.ir import (
+    CELRuleIR,
+    PolicyIR,
+    ResourceRequirementIR,
+    compile_policy,
+)
 from tessera.identity import (
     AgentIdentity,
     AgentIdentityVerifier,
@@ -59,9 +65,19 @@ from tessera.identity import (
     jwk_thumbprint,
 )
 from tessera.labels import Origin, TrustLabel, TrustLevel, sign_label, verify_label
+from tessera.cel_engine import CELContext, CELDecision, CELNotAvailable, CELPolicyEngine, CELRule
 from tessera.mcp import MCPInterceptor, MCPSecurityContext
 from tessera.mtls import MTLSPeerIdentity, MTLSPeerVerificationError, extract_peer_identity
-from tessera.policy import Decision, DecisionKind, Policy, PolicyViolation, ToolRequirement
+from tessera.policy import (
+    Decision,
+    DecisionKind,
+    Policy,
+    PolicyScope,
+    PolicyViolation,
+    ResourceRequirement,
+    ResourceType,
+    ToolRequirement,
+)
 from tessera.policy_backends import (
     OPAPolicyBackend,
     OPAStatus,
@@ -84,8 +100,13 @@ from tessera.quarantine import (
     split_by_trust,
     strict_worker,
 )
+from tessera.hooks.client import RemoteHookClient
+from tessera.hooks.dispatcher import HookDispatcher
 from tessera.redaction import Secret, SecretRegistry, redact_nested
 from tessera.registry import ToolRegistry
+from tessera.xds.client import XDSClient
+from tessera.xds.server import XDSServer
+from tessera.sessions import PendingApproval, SessionStore
 from tessera.signing import (
     HMACSigner,
     HMACVerifier,
@@ -113,6 +134,12 @@ __all__ = [
     "A2ASecurityContext",
     "A2ATaskRequest",
     "A2AVerificationError",
+    "CELContext",
+    "CELDecision",
+    "CELNotAvailable",
+    "CELPolicyEngine",
+    "CELRule",
+    "CELRuleIR",
     "AgentIdentity",
     "AgentIdentityVerifier",
     "AgentHeartbeat",
@@ -138,6 +165,7 @@ __all__ = [
     "HMACControlPlaneSigner",
     "HMACControlPlaneVerifier",
     "HMACVerifier",
+    "HookDispatcher",
     "JWKSAgentIdentityVerifier",
     "JWKSVerifier",
     "JWTControlPlaneSigner",
@@ -160,6 +188,7 @@ __all__ = [
     "OPAControlConfig",
     "Origin",
     "OPAPolicyBackend",
+    "PolicyIR",
     "Policy",
     "PolicyBackend",
     "PolicyBackendDecision",
@@ -167,6 +196,7 @@ __all__ = [
     "PolicyDistributionInput",
     "PolicyDelegationSummary",
     "PolicyInput",
+    "PolicyScope",
     "PolicyViolation",
     "PolicySegmentSummary",
     "PromptProvenanceManifest",
@@ -181,14 +211,23 @@ __all__ = [
     "SpireNotAvailable",
     "SpireProtocolError",
     "SignedEvidenceBundle",
+    "ResourceRequirement",
+    "ResourceRequirementIR",
+    "ResourceType",
+    "RemoteHookClient",
     "RegistryDistributionInput",
+    "PendingApproval",
+    "SessionStore",
     "ToolRegistry",
     "ToolRequirement",
     "TrustLabel",
     "TrustLevel",
     "WorkerReport",
     "WorkerSchemaViolation",
+    "XDSClient",
+    "XDSServer",
     "attach_security_context",
+    "compile_policy",
     "async_webhook_sink",
     "create_control_plane_app",
     "emit_event",

--- a/src/tessera/approval.py
+++ b/src/tessera/approval.py
@@ -9,6 +9,7 @@ and waits for an allow/deny response.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import httpx
@@ -123,6 +124,11 @@ class ApprovalGate:
     Sends an ApprovalRequest to the configured URL and interprets the
     JSON response as an ApprovalResponse. Returns a final ALLOW or DENY
     Decision based on the human's response.
+
+    When a session_store is provided, pending approvals are persisted
+    before the webhook call and the session_id is included in the
+    webhook payload. The webhook response is validated against the
+    stored session before resolving.
     """
 
     def __init__(
@@ -130,10 +136,12 @@ class ApprovalGate:
         webhook_url: str,
         timeout: float = 300.0,
         transport: Any = None,
+        session_store: Any = None,
     ) -> None:
         self._url = webhook_url
         self._timeout = timeout
         self._transport = transport
+        self._session_store = session_store
 
     def request_approval(
         self, decision: Decision, principal: str, context_summary: str,
@@ -141,7 +149,9 @@ class ApprovalGate:
         """Send the approval request and return the resolved decision.
 
         Emits HUMAN_APPROVAL_REQUIRED before the webhook call and
-        HUMAN_APPROVAL_RESOLVED after.
+        HUMAN_APPROVAL_RESOLVED after. When a session store is
+        configured, stores the pending approval and includes the
+        session_id in the webhook payload.
         """
         req = ApprovalRequest(
             tool=decision.tool,
@@ -152,17 +162,43 @@ class ApprovalGate:
 
         _emit_required(decision, principal, self._url)
 
+        payload = req.to_dict()
+        if self._session_store is not None:
+            from tessera.sessions import PendingApproval, make_session_id
+
+            now = datetime.now(timezone.utc)
+            pending = PendingApproval(
+                session_id=make_session_id(),
+                tool=decision.tool,
+                principal=principal,
+                decision=decision,
+                context_summary=context_summary,
+                created_at=now,
+                expires_at=now + self._session_store._ttl,
+            )
+            self._session_store.store(pending)
+            payload["session_id"] = pending.session_id
+
         client_kwargs: dict[str, Any] = {"timeout": self._timeout}
         if self._transport is not None:
             client_kwargs["transport"] = self._transport
 
         try:
             with httpx.Client(**client_kwargs) as client:
-                resp = client.post(self._url, json=req.to_dict())
+                resp = client.post(self._url, json=payload)
                 resp.raise_for_status()
                 body = resp.json()
         except Exception as exc:
             return _fail_closed(decision, principal, exc)
+
+        if self._session_store is not None:
+            session_id = payload["session_id"]
+            stored = self._session_store.retrieve(session_id)
+            if stored is None:
+                return _fail_closed(
+                    decision, principal,
+                    RuntimeError("session expired or not found"),
+                )
 
         return _resolve(decision, body, principal)
 
@@ -175,10 +211,12 @@ class AsyncApprovalGate:
         webhook_url: str,
         timeout: float = 300.0,
         transport: Any = None,
+        session_store: Any = None,
     ) -> None:
         self._url = webhook_url
         self._timeout = timeout
         self._transport = transport
+        self._session_store = session_store
 
     async def request_approval(
         self, decision: Decision, principal: str, context_summary: str,
@@ -193,16 +231,42 @@ class AsyncApprovalGate:
 
         _emit_required(decision, principal, self._url)
 
+        payload = req.to_dict()
+        if self._session_store is not None:
+            from tessera.sessions import PendingApproval, make_session_id
+
+            now = datetime.now(timezone.utc)
+            pending = PendingApproval(
+                session_id=make_session_id(),
+                tool=decision.tool,
+                principal=principal,
+                decision=decision,
+                context_summary=context_summary,
+                created_at=now,
+                expires_at=now + self._session_store._ttl,
+            )
+            self._session_store.store(pending)
+            payload["session_id"] = pending.session_id
+
         client_kwargs: dict[str, Any] = {"timeout": self._timeout}
         if self._transport is not None:
             client_kwargs["transport"] = self._transport
 
         try:
             async with httpx.AsyncClient(**client_kwargs) as client:
-                resp = await client.post(self._url, json=req.to_dict())
+                resp = await client.post(self._url, json=payload)
                 resp.raise_for_status()
                 body = resp.json()
         except Exception as exc:
             return _fail_closed(decision, principal, exc)
+
+        if self._session_store is not None:
+            session_id = payload["session_id"]
+            stored = self._session_store.retrieve(session_id)
+            if stored is None:
+                return _fail_closed(
+                    decision, principal,
+                    RuntimeError("session expired or not found"),
+                )
 
         return _resolve(decision, body, principal)

--- a/src/tessera/cel_engine.py
+++ b/src/tessera/cel_engine.py
@@ -1,0 +1,116 @@
+"""CEL-based policy evaluation for attribute-driven deny rules.
+
+CEL expressions are evaluated after the taint-floor check passes.
+They act as deny-only refinements: a CEL rule can block an otherwise-
+allowed tool call but cannot allow a taint-denied one. This follows
+the same pattern as the OPA backend in policy_backends.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+
+class CELNotAvailable(RuntimeError):
+    """Raised when cel-python is not installed."""
+
+
+@dataclass(frozen=True)
+class CELRule:
+    """A single CEL deny rule.
+
+    Args:
+        name: Human-readable rule identifier.
+        expression: CEL expression that evaluates to a boolean.
+        action: Either "deny" or "require_approval".
+        message: Explanation surfaced when the rule fires.
+    """
+
+    name: str
+    expression: str
+    action: str  # "deny" or "require_approval"
+    message: str
+
+
+@dataclass(frozen=True)
+class CELContext:
+    """Variables available inside CEL expressions.
+
+    Each field maps to a CEL variable of the same name.
+    """
+
+    tool: str
+    args: dict[str, Any]
+    min_trust: int
+    principal: str
+    segment_count: int
+    delegation_subject: str | None
+    delegation_actions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CELDecision:
+    """Result when a CEL rule fires."""
+
+    rule_name: str
+    action: str
+    message: str
+
+
+class CELPolicyEngine:
+    """Evaluates a sequence of CEL deny rules against a CELContext.
+
+    Requires the cel-python package. If cel-python is not installed,
+    the constructor raises CELNotAvailable.
+    """
+
+    def __init__(self, rules: Sequence[CELRule]) -> None:
+        try:
+            import celpy
+            import celpy.celtypes
+        except ImportError as exc:
+            raise CELNotAvailable(
+                "cel-python is required for CEL policy rules. "
+                "Install it with: pip install tessera[cel]"
+            ) from exc
+
+        self._celpy = celpy
+        self._celtypes = celpy.celtypes
+        self._rules = list(rules)
+        self._compiled: list[tuple[CELRule, Any]] = []
+
+        env = celpy.Environment()
+        for rule in self._rules:
+            ast = env.compile(rule.expression)
+            prog = env.program(ast)
+            self._compiled.append((rule, prog))
+
+    def evaluate(self, context: CELContext) -> CELDecision | None:
+        """Evaluate each rule in order. Return the first that fires, or None."""
+        activation = self._build_activation(context)
+        for rule, prog in self._compiled:
+            result = prog.evaluate(activation)
+            if result:
+                return CELDecision(
+                    rule_name=rule.name,
+                    action=rule.action,
+                    message=rule.message,
+                )
+        return None
+
+    def _build_activation(self, context: CELContext) -> dict[str, Any]:
+        """Convert a CELContext into a cel-python activation dict."""
+        ct = self._celtypes
+        return {
+            "tool": ct.StringType(context.tool),
+            "min_trust": ct.IntType(context.min_trust),
+            "principal": ct.StringType(context.principal),
+            "segment_count": ct.IntType(context.segment_count),
+            "delegation_subject": ct.StringType(
+                context.delegation_subject or ""
+            ),
+            "delegation_actions": ct.ListType(
+                elements=[ct.StringType(a) for a in context.delegation_actions]
+            ),
+        }

--- a/src/tessera/events.py
+++ b/src/tessera/events.py
@@ -44,6 +44,7 @@ class EventKind(StrEnum):
     DELEGATION_VERIFY_FAILURE = "delegation_verify_failure"
     HUMAN_APPROVAL_REQUIRED = "human_approval_required"
     HUMAN_APPROVAL_RESOLVED = "human_approval_resolved"
+    SESSION_EXPIRED = "session_expired"
 
 
 @dataclass(frozen=True)

--- a/src/tessera/hooks/client.py
+++ b/src/tessera/hooks/client.py
@@ -1,0 +1,78 @@
+"""HTTP client for calling remote extension servers.
+
+Remote hooks are called via HTTP POST. On any error (timeout,
+network failure, non-2xx response), the client fails closed,
+treating the result as a deny.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from tessera.policy import Decision, DecisionKind
+
+
+class RemoteHookClient:
+    """Call a remote extension server via HTTP POST.
+
+    Implements the PostPolicyEvaluateHook protocol so it can be
+    registered directly with HookDispatcher.register_policy_hook.
+    """
+
+    def __init__(self, url: str, timeout: float = 5.0) -> None:
+        self._url = url
+        self._timeout = timeout
+
+    def __call__(
+        self, tool: str, principal: str, decision: Decision
+    ) -> Decision | None:
+        return self.post_policy_evaluate(tool, principal, decision)
+
+    def post_policy_evaluate(
+        self, tool: str, principal: str, decision: Decision
+    ) -> Decision | None:
+        """POST to the remote hook and return the modified decision, or None.
+
+        On timeout or error, fails closed by returning a DENY decision.
+        """
+        payload = {
+            "tool": tool,
+            "principal": principal,
+            "decision_kind": str(decision.kind),
+            "reason": decision.reason,
+            "required_trust": int(decision.required_trust),
+            "observed_trust": int(decision.observed_trust),
+        }
+        try:
+            resp = httpx.post(
+                self._url,
+                json=payload,
+                timeout=self._timeout,
+            )
+            resp.raise_for_status()
+            body = resp.json()
+        except Exception:
+            return Decision(
+                kind=DecisionKind.DENY,
+                reason="remote hook unavailable, failing closed",
+                tool=tool,
+                required_trust=decision.required_trust,
+                observed_trust=decision.observed_trust,
+            )
+
+        new_kind = body.get("decision_kind")
+        if new_kind is None:
+            return None
+
+        # Deny-only: only accept downgrades to DENY.
+        if new_kind == DecisionKind.DENY and decision.kind != DecisionKind.DENY:
+            return Decision(
+                kind=DecisionKind.DENY,
+                reason=body.get("reason", "denied by remote hook"),
+                tool=tool,
+                required_trust=decision.required_trust,
+                observed_trust=decision.observed_trust,
+            )
+        return None

--- a/src/tessera/hooks/dispatcher.py
+++ b/src/tessera/hooks/dispatcher.py
@@ -1,0 +1,121 @@
+"""Extension hook dispatcher for post-processing policy decisions.
+
+Hooks are deny-only: they can downgrade ALLOW to DENY but cannot
+upgrade DENY to ALLOW. This preserves the taint floor invariant.
+A hook returning None leaves the decision unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol
+
+from tessera.events import EventKind, SecurityEvent, emit as emit_event
+from tessera.policy import Decision, DecisionKind
+
+
+class PostPolicyEvaluateHook(Protocol):
+    """Hook called after policy evaluation.
+
+    Return a modified Decision to override (deny-only), or None
+    to accept the original.
+    """
+
+    def __call__(
+        self, tool: str, principal: str, decision: Decision
+    ) -> Decision | None: ...
+
+
+class PostToolCallGateHook(Protocol):
+    """Hook called before a tool invocation is dispatched.
+
+    Return False to block the call, True to allow it.
+    """
+
+    def __call__(
+        self, tool: str, args: dict[str, Any], principal: str
+    ) -> bool: ...
+
+
+class HookDispatcher:
+    """Dispatch post-processing hooks at key extension points.
+
+    All hooks are deny-only. A policy hook can change ALLOW to DENY
+    but cannot change DENY to ALLOW. Tool call hooks block on any
+    False return. Errors in hooks fail closed (deny).
+    """
+
+    def __init__(self) -> None:
+        self._policy_hooks: list[PostPolicyEvaluateHook] = []
+        self._tool_call_hooks: list[PostToolCallGateHook] = []
+
+    def register_policy_hook(self, hook: PostPolicyEvaluateHook) -> None:
+        """Register a post-policy-evaluation hook."""
+        self._policy_hooks.append(hook)
+
+    def register_tool_call_hook(self, hook: PostToolCallGateHook) -> None:
+        """Register a pre-tool-call gate hook."""
+        self._tool_call_hooks.append(hook)
+
+    def dispatch_policy(
+        self, tool: str, principal: str, decision: Decision
+    ) -> Decision:
+        """Run all policy hooks. A hook returning DENY overrides ALLOW.
+
+        Hooks cannot upgrade DENY to ALLOW. If a hook raises, the
+        dispatcher fails closed and returns DENY.
+        """
+        current = decision
+        for hook in self._policy_hooks:
+            try:
+                result = hook(tool, principal, current)
+            except Exception:
+                emit_event(
+                    SecurityEvent.now(
+                        kind=EventKind.POLICY_DENY,
+                        principal=principal,
+                        detail={
+                            "tool": tool,
+                            "reason": "hook raised, failing closed",
+                        },
+                    )
+                )
+                return Decision(
+                    kind=DecisionKind.DENY,
+                    reason="extension hook error, failing closed",
+                    tool=tool,
+                    required_trust=current.required_trust,
+                    observed_trust=current.observed_trust,
+                )
+            if result is None:
+                continue
+            # Deny-only: hooks can downgrade ALLOW to DENY but not
+            # upgrade DENY to ALLOW.
+            if current.kind != DecisionKind.DENY and result.kind == DecisionKind.DENY:
+                current = result
+        return current
+
+    def dispatch_tool_call(
+        self, tool: str, args: dict[str, Any], principal: str
+    ) -> bool:
+        """Run all tool call hooks. Any returning False blocks the call.
+
+        If a hook raises, the dispatcher fails closed and returns False.
+        """
+        for hook in self._tool_call_hooks:
+            try:
+                allowed = hook(tool, args, principal)
+            except Exception:
+                emit_event(
+                    SecurityEvent.now(
+                        kind=EventKind.POLICY_DENY,
+                        principal=principal,
+                        detail={
+                            "tool": tool,
+                            "reason": "tool call hook raised, failing closed",
+                        },
+                    )
+                )
+                return False
+            if not allowed:
+                return False
+        return True

--- a/src/tessera/ir.py
+++ b/src/tessera/ir.py
@@ -1,0 +1,181 @@
+"""Intermediate representation for policy configuration.
+
+The IR decouples config parsing from policy execution. All input
+formats (YAML dicts, CEL strings, Cedar, OPA/Rego) produce the same
+IR types. The IR compiles to live Policy instances via compile_policy().
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from tessera.labels import TrustLevel
+
+_TRUST_NAMES: dict[str, TrustLevel] = {
+    "untrusted": TrustLevel.UNTRUSTED,
+    "tool": TrustLevel.TOOL,
+    "user": TrustLevel.USER,
+    "system": TrustLevel.SYSTEM,
+}
+
+
+def _parse_trust(value: str | int) -> int:
+    """Resolve a trust level string or int to its integer value."""
+    if isinstance(value, int):
+        return TrustLevel(value).value
+    key = value.strip().lower()
+    if key not in _TRUST_NAMES:
+        raise ValueError(
+            f"unknown trust level {value!r}, expected one of {list(_TRUST_NAMES)}"
+        )
+    return _TRUST_NAMES[key].value
+
+
+@dataclass(frozen=True)
+class ResourceRequirementIR:
+    """One resource requirement in the IR."""
+
+    name: str
+    resource_type: str = "tool"  # "tool", "prompt", "resource"
+    required_trust: int = 100  # TrustLevel int value
+
+
+@dataclass(frozen=True)
+class CELRuleIR:
+    """One CEL deny rule in the IR."""
+
+    name: str
+    expression: str
+    action: str = "deny"  # "deny" or "require_approval"
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class PolicyIR:
+    """Complete policy configuration in intermediate form."""
+
+    requirements: tuple[ResourceRequirementIR, ...] = ()
+    scope: str = "agent"  # "mesh", "team", "agent"
+    default_trust: int = 100  # TrustLevel.USER
+    cel_rules: tuple[CELRuleIR, ...] = ()
+    human_approval_tools: frozenset[str] = field(default_factory=frozenset)
+
+
+def compile_policy(ir: PolicyIR) -> Any:
+    """Compile a PolicyIR into a live tessera.policy.Policy instance.
+
+    Imports Policy at call time to avoid circular imports. Resilient
+    to missing optional features (PolicyScope, ResourceType,
+    CELPolicyEngine): the IR still compiles to a basic Policy when
+    those types are not yet available.
+    """
+    from tessera.policy import Policy
+
+    policy = Policy(default_required_trust=TrustLevel(ir.default_trust))
+
+    # Try to set scope if PolicyScope exists.
+    try:
+        from tessera.policy import PolicyScope  # type: ignore[attr-defined]
+        policy.scope = PolicyScope(ir.scope)
+    except (ImportError, AttributeError, ValueError):
+        pass
+
+    # Add requirements.
+    for req in ir.requirements:
+        try:
+            from tessera.policy import ResourceType  # type: ignore[attr-defined]
+            policy.require(
+                req.name,
+                TrustLevel(req.required_trust),
+                resource_type=ResourceType(req.resource_type),
+            )
+        except (ImportError, AttributeError, TypeError):
+            policy.require(req.name, TrustLevel(req.required_trust))
+
+    # Add human approval tools.
+    for tool in ir.human_approval_tools:
+        policy.requires_human_approval(tool)
+
+    # Add CEL engine if rules are present.
+    if ir.cel_rules:
+        try:
+            from tessera.cel_engine import CELPolicyEngine, CELRule  # type: ignore[import-not-found]
+            rules = [
+                CELRule(
+                    name=r.name,
+                    expression=r.expression,
+                    action=r.action,
+                    message=r.message,
+                )
+                for r in ir.cel_rules
+            ]
+            policy.cel_engine = CELPolicyEngine(rules)  # type: ignore[attr-defined]
+        except ImportError:
+            pass
+
+    return policy
+
+
+def from_dict(data: dict[str, Any]) -> PolicyIR:
+    """Parse a dict (from YAML, JSON, or inline) into PolicyIR.
+
+    Expected keys:
+      requirements or tool_policies: list of {name, resource_type?, required_trust}
+      scope: "mesh" | "team" | "agent"
+      default_trust or default_required_trust: trust level name or int
+      cel_rules: list of {name, expression, action?, message?}
+      human_approval_tools: list of tool names
+    """
+    raw_reqs = data.get("requirements") or data.get("tool_policies") or []
+    requirements = tuple(
+        ResourceRequirementIR(
+            name=r["name"],
+            resource_type=r.get("resource_type", "tool"),
+            required_trust=_parse_trust(r.get("required_trust", 100)),
+        )
+        for r in raw_reqs
+    )
+
+    raw_trust = data.get("default_trust") or data.get("default_required_trust")
+    default_trust = _parse_trust(raw_trust) if raw_trust is not None else 100
+
+    scope = data.get("scope", "agent")
+
+    raw_cel = data.get("cel_rules") or []
+    cel_rules = tuple(
+        CELRuleIR(
+            name=c["name"],
+            expression=c["expression"],
+            action=c.get("action", "deny"),
+            message=c.get("message", ""),
+        )
+        for c in raw_cel
+    )
+
+    raw_approval = data.get("human_approval_tools") or []
+    human_approval_tools = frozenset(raw_approval)
+
+    return PolicyIR(
+        requirements=requirements,
+        scope=scope,
+        default_trust=default_trust,
+        cel_rules=cel_rules,
+        human_approval_tools=human_approval_tools,
+    )
+
+
+def from_yaml_string(text: str) -> PolicyIR:
+    """Parse a YAML string into PolicyIR. Requires PyYAML."""
+    import yaml  # type: ignore[import-untyped]
+
+    return from_dict(yaml.safe_load(text))
+
+
+def from_yaml_path(path: str) -> PolicyIR:
+    """Load a YAML file into PolicyIR. Requires PyYAML."""
+    from pathlib import Path
+
+    import yaml  # type: ignore[import-untyped]
+
+    return from_dict(yaml.safe_load(Path(path).read_text(encoding="utf-8")))

--- a/src/tessera/policy.py
+++ b/src/tessera/policy.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from tessera.context import Context
@@ -22,6 +22,9 @@ from tessera.events import EventKind, SecurityEvent, emit as emit_event
 from tessera.labels import TrustLevel
 from tessera.policy_backends import PolicyBackend, PolicyInput
 from tessera.telemetry import emit_decision
+
+if TYPE_CHECKING:
+    from tessera.cel_engine import CELPolicyEngine
 
 
 class PolicyViolation(Exception):
@@ -32,6 +35,33 @@ class DecisionKind(StrEnum):
     ALLOW = "allow"
     DENY = "deny"
     REQUIRE_APPROVAL = "require_approval"
+
+
+class ResourceType(StrEnum):
+    """MCP resource types subject to policy."""
+
+    TOOL = "tool"
+    PROMPT = "prompt"
+    RESOURCE = "resource"
+
+
+class PolicyScope(StrEnum):
+    """Hierarchy level for policy targeting.
+
+    Scope priority: MESH > TEAM > AGENT. Higher scopes set trust
+    floors that lower scopes can tighten but not loosen.
+    """
+
+    MESH = "mesh"
+    TEAM = "team"
+    AGENT = "agent"
+
+
+_SCOPE_PRIORITY: dict[PolicyScope, int] = {
+    PolicyScope.MESH: 0,
+    PolicyScope.TEAM: 1,
+    PolicyScope.AGENT: 2,
+}
 
 
 @dataclass(frozen=True)
@@ -52,8 +82,8 @@ class Decision:
 
 
 @dataclass(frozen=True)
-class ToolRequirement:
-    """Minimum trust level a tool requires to fire.
+class ResourceRequirement:
+    """Minimum trust level a resource requires to be accessed.
 
     Sensitive tools that mutate external state or exfiltrate data should
     require TrustLevel.USER. Read-only tools can run at TrustLevel.TOOL.
@@ -61,23 +91,41 @@ class ToolRequirement:
     """
 
     name: str
-    required_trust: TrustLevel
+    resource_type: ResourceType = ResourceType.TOOL
+    required_trust: TrustLevel = TrustLevel.USER
+
+
+# Backward-compatible alias.
+ToolRequirement = ResourceRequirement
 
 
 @dataclass
 class Policy:
     """Per-tool trust requirements with deny-by-default semantics."""
 
-    requirements: dict[str, ToolRequirement] = field(default_factory=dict)
+    requirements: dict[tuple[str, ResourceType], ResourceRequirement] = field(
+        default_factory=dict,
+    )
     default_required_trust: TrustLevel = TrustLevel.USER
     backend: PolicyBackend | None = None
     fail_closed_backend_errors: bool = True
     base_requirements: dict[str, ToolRequirement] | None = None
     request_requirements: dict[str, ToolRequirement] = field(default_factory=dict)
     _human_approval_tools: set[str] = field(default_factory=set)
+    scope: PolicyScope = PolicyScope.AGENT
+    cel_engine: CELPolicyEngine | None = None
 
-    def require(self, name: str, level: TrustLevel) -> None:
-        self.requirements[name] = ToolRequirement(name=name, required_trust=level)
+    def require(
+        self,
+        name: str,
+        level: TrustLevel,
+        resource_type: ResourceType = ResourceType.TOOL,
+    ) -> None:
+        self.requirements[(name, resource_type)] = ResourceRequirement(
+            name=name,
+            resource_type=resource_type,
+            required_trust=level,
+        )
 
     def requires_human_approval(self, tool: str) -> None:
         """Mark a tool as requiring human approval regardless of trust level."""
@@ -90,6 +138,7 @@ class Policy:
         args: dict[str, Any] | None = None,
         delegation: DelegationToken | None = None,
         expected_delegate: str | None = None,
+        resource_type: ResourceType = ResourceType.TOOL,
     ) -> Decision:
         """Return an allow or deny decision for a proposed tool call.
 
@@ -100,9 +149,10 @@ class Policy:
         Delegation adds extra deny conditions. It never widens access
         beyond what the trust floor allows.
         """
+        key = (tool_name, resource_type)
         required = (
-            self.requirements[tool_name].required_trust
-            if tool_name in self.requirements
+            self.requirements[key].required_trust
+            if key in self.requirements
             else self.default_required_trust
         )
         if self.base_requirements is None:
@@ -191,6 +241,42 @@ class Policy:
             )
             backend_name = None
             metadata = {}
+        # CEL deny rules: evaluated after taint floor passes. A CEL rule
+        # can block or require approval but cannot allow a taint-denied call.
+        if decision.allowed and self.cel_engine is not None:
+            from tessera.cel_engine import CELContext as _CELCtx
+
+            cel_ctx = _CELCtx(
+                tool=tool_name,
+                args=args or {},
+                min_trust=int(observed),
+                principal=context.principal or "",
+                segment_count=len(context.segments),
+                delegation_subject=(
+                    delegation.subject if delegation else None
+                ),
+                delegation_actions=(
+                    tuple(delegation.authorized_actions) if delegation else ()
+                ),
+            )
+            cel_result = self.cel_engine.evaluate(cel_ctx)
+            if cel_result is not None:
+                if cel_result.action == "deny":
+                    decision = Decision(
+                        kind=DecisionKind.DENY,
+                        reason=f"CEL rule {cel_result.rule_name!r}: {cel_result.message}",
+                        tool=tool_name,
+                        required_trust=required,
+                        observed_trust=observed,
+                    )
+                elif cel_result.action == "require_approval":
+                    decision = Decision(
+                        kind=DecisionKind.REQUIRE_APPROVAL,
+                        reason=f"CEL rule {cel_result.rule_name!r}: {cel_result.message}",
+                        tool=tool_name,
+                        required_trust=required,
+                        observed_trust=observed,
+                    )
         # Human approval gate: only triggers when taint floor allows the call.
         # DENY always takes precedence.
         if decision.allowed and tool_name in self._human_approval_tools:
@@ -251,6 +337,64 @@ class Policy:
         if not decision.allowed:
             raise PolicyViolation(decision.reason)
         return decision
+
+    @classmethod
+    def merge(cls, *policies: Policy) -> Policy:
+        """Merge policies from multiple scopes into one.
+
+        Scope priority: MESH > TEAM > AGENT. Higher scopes set trust
+        floors that lower scopes can tighten (raise) but not loosen
+        (lower). This prevents an agent from relaxing org-wide policy.
+
+        Human-approval-required tools from any scope are unioned.
+        CEL engines from all scopes contribute rules evaluated in
+        scope-priority order.
+        """
+        if not policies:
+            return cls()
+
+        sorted_policies = sorted(
+            policies,
+            key=lambda p: _SCOPE_PRIORITY.get(p.scope, 2),
+        )
+
+        # Use default_required_trust from the highest-priority scope.
+        merged_default = sorted_policies[0].default_required_trust
+
+        # For each requirement key, take the highest required_trust
+        # across all scopes (lower scopes can tighten, not loosen).
+        merged_reqs: dict[tuple[str, ResourceType], ResourceRequirement] = {}
+        for policy in sorted_policies:
+            for key, req in policy.requirements.items():
+                if key not in merged_reqs:
+                    merged_reqs[key] = req
+                elif req.required_trust > merged_reqs[key].required_trust:
+                    merged_reqs[key] = req
+
+        # Union all human-approval tools.
+        merged_approval: set[str] = set()
+        for policy in sorted_policies:
+            merged_approval |= policy._human_approval_tools
+
+        # Concatenate CEL rules from all scopes in priority order.
+        merged_cel: CELPolicyEngine | None = None
+        all_cel_rules: list[Any] = []
+        for policy in sorted_policies:
+            if policy.cel_engine is not None:
+                all_cel_rules.extend(policy.cel_engine._rules)
+        if all_cel_rules:
+            from tessera.cel_engine import CELPolicyEngine
+
+            merged_cel = CELPolicyEngine(all_cel_rules)
+
+        result = cls(
+            requirements=merged_reqs,
+            default_required_trust=merged_default,
+            _human_approval_tools=merged_approval,
+            scope=sorted_policies[0].scope,
+            cel_engine=merged_cel,
+        )
+        return result
 
 
 def _delegation_deny_reason(

--- a/src/tessera/proxy.py
+++ b/src/tessera/proxy.py
@@ -757,12 +757,15 @@ def _jsonrpc_error(
 
 def _policy_for_request(base_policy: Policy, tools: list[ToolModel]) -> Policy:
     """Copy the base policy, then apply the caller's declared tool surface."""
+    base_reqs_by_name = {
+        req.name: req for req in base_policy.requirements.values()
+    }
     request_policy = Policy(
         requirements=deepcopy(base_policy.requirements),
         default_required_trust=base_policy.default_required_trust,
         backend=base_policy.backend,
         fail_closed_backend_errors=base_policy.fail_closed_backend_errors,
-        base_requirements=deepcopy(base_policy.requirements),
+        base_requirements=base_reqs_by_name,
         _human_approval_tools=set(base_policy._human_approval_tools),
     )
     for tool in tools:

--- a/src/tessera/sessions.py
+++ b/src/tessera/sessions.py
@@ -1,0 +1,211 @@
+"""Encrypted in-memory session store for pending approvals.
+
+When a tool call requires human approval, the proxy stores the
+pending decision in a session. The approval webhook response resolves
+the session. Expired sessions auto-resolve as DENY (fail closed).
+
+Sessions are encrypted at rest using Fernet symmetric encryption when
+an encryption key is provided. Without a key, sessions are stored in
+plaintext (suitable for development but not production).
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from threading import Lock
+from typing import Any
+
+from tessera.policy import Decision, DecisionKind
+from tessera.events import EventKind, SecurityEvent, emit as emit_event
+
+
+@dataclass
+class PendingApproval:
+    """One suspended tool-call decision awaiting human review."""
+
+    session_id: str
+    tool: str
+    principal: str
+    decision: Decision
+    context_summary: str
+    created_at: datetime
+    expires_at: datetime
+
+    def is_expired(self) -> bool:
+        return datetime.now(timezone.utc) >= self.expires_at
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "tool": self.tool,
+            "principal": self.principal,
+            "decision": {
+                "kind": str(self.decision.kind),
+                "reason": self.decision.reason,
+                "tool": self.decision.tool,
+                "required_trust": int(self.decision.required_trust),
+                "observed_trust": int(self.decision.observed_trust),
+            },
+            "context_summary": self.context_summary,
+            "created_at": self.created_at.isoformat(),
+            "expires_at": self.expires_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PendingApproval:
+        """Reconstruct from serialized dict."""
+        from tessera.labels import TrustLevel
+
+        d = data["decision"]
+        decision = Decision(
+            kind=DecisionKind(d["kind"]),
+            reason=d["reason"],
+            tool=d["tool"],
+            required_trust=TrustLevel(d["required_trust"]),
+            observed_trust=TrustLevel(d["observed_trust"]),
+        )
+        return cls(
+            session_id=data["session_id"],
+            tool=data["tool"],
+            principal=data["principal"],
+            decision=decision,
+            context_summary=data["context_summary"],
+            created_at=datetime.fromisoformat(data["created_at"]),
+            expires_at=datetime.fromisoformat(data["expires_at"]),
+        )
+
+
+class SessionStore:
+    """Thread-safe session store with optional Fernet encryption."""
+
+    def __init__(
+        self,
+        ttl: timedelta = timedelta(minutes=5),
+        encryption_key: bytes | None = None,
+    ) -> None:
+        self._ttl = ttl
+        self._lock = Lock()
+        self._sessions: dict[str, bytes | str] = {}
+        self._fernet: Any = None
+        if encryption_key is not None:
+            try:
+                from cryptography.fernet import Fernet
+                import base64
+
+                # Fernet requires a 32-byte key, base64url-encoded.
+                raw = encryption_key[:32].ljust(32, b"\0")
+                key = base64.urlsafe_b64encode(raw)
+                self._fernet = Fernet(key)
+            except ImportError:
+                pass
+
+    def _serialize(self, approval: PendingApproval) -> bytes | str:
+        payload = json.dumps(approval.to_dict())
+        if self._fernet is not None:
+            return self._fernet.encrypt(payload.encode("utf-8"))
+        return payload
+
+    def _deserialize(self, raw: bytes | str) -> PendingApproval:
+        if self._fernet is not None:
+            payload = self._fernet.decrypt(raw).decode("utf-8")  # type: ignore[arg-type]
+        else:
+            payload = raw  # type: ignore[assignment]
+        return PendingApproval.from_dict(json.loads(payload))
+
+    def store(self, approval: PendingApproval) -> str:
+        """Store a pending approval. Returns the session_id."""
+        with self._lock:
+            self._sessions[approval.session_id] = self._serialize(approval)
+        return approval.session_id
+
+    def retrieve(self, session_id: str) -> PendingApproval | None:
+        """Retrieve and return None if not found or expired."""
+        with self._lock:
+            raw = self._sessions.get(session_id)
+        if raw is None:
+            return None
+        approval = self._deserialize(raw)
+        if approval.is_expired():
+            return None
+        return approval
+
+    def resolve(
+        self,
+        session_id: str,
+        approved: bool,
+        approver: str,
+        reason: str = "",
+    ) -> Decision:
+        """Resolve a pending approval and return the final decision.
+
+        Removes the session from the store. If the session is expired
+        or not found, returns DENY (fail closed).
+        """
+        with self._lock:
+            raw = self._sessions.pop(session_id, None)
+        if raw is None:
+            return _deny_decision("session not found")
+
+        approval = self._deserialize(raw)
+        if approval.is_expired():
+            return _deny_decision("session expired")
+
+        resolved_kind = DecisionKind.ALLOW if approved else DecisionKind.DENY
+        resolved_reason = (
+            f"approved by {approver}: {reason}" if approved
+            else f"denied by {approver}: {reason}"
+        )
+        return Decision(
+            kind=resolved_kind,
+            reason=resolved_reason,
+            tool=approval.tool,
+            required_trust=approval.decision.required_trust,
+            observed_trust=approval.decision.observed_trust,
+        )
+
+    def expire_stale(self) -> int:
+        """Remove all expired sessions. Returns the count removed."""
+        now = datetime.now(timezone.utc)
+        expired_ids: list[str] = []
+        with self._lock:
+            for sid, raw in list(self._sessions.items()):
+                approval = self._deserialize(raw)
+                if now >= approval.expires_at:
+                    expired_ids.append(sid)
+            for sid in expired_ids:
+                del self._sessions[sid]
+
+        for sid in expired_ids:
+            emit_event(
+                SecurityEvent.now(
+                    kind=EventKind.SESSION_EXPIRED,
+                    principal="system",
+                    detail={"session_id": sid},
+                )
+            )
+        return len(expired_ids)
+
+    def __len__(self) -> int:
+        """Number of active sessions."""
+        with self._lock:
+            return len(self._sessions)
+
+
+def make_session_id() -> str:
+    """Generate a cryptographically random session identifier."""
+    return secrets.token_urlsafe(32)
+
+
+def _deny_decision(reason: str) -> Decision:
+    from tessera.labels import TrustLevel
+
+    return Decision(
+        kind=DecisionKind.DENY,
+        reason=reason,
+        tool="unknown",
+        required_trust=TrustLevel.USER,
+        observed_trust=TrustLevel.UNTRUSTED,
+    )

--- a/src/tessera/xds/client.py
+++ b/src/tessera/xds/client.py
@@ -1,0 +1,45 @@
+"""xDS client for agents to receive policy updates.
+
+Fetches state-of-the-world snapshots and subscribes to SSE
+streams for push updates from the xDS server.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+import httpx
+
+
+class XDSClient:
+    """Client for the Tessera xDS resource distribution server."""
+
+    def __init__(self, server_url: str, timeout: float = 10.0) -> None:
+        self._server_url = server_url.rstrip("/")
+        self._timeout = timeout
+
+    async def fetch(self, type_url: str) -> dict[str, Any]:
+        """Fetch current state of the world for a resource type."""
+        url = f"{self._server_url}/xds/v1/{type_url}"
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            return resp.json()
+
+    async def subscribe(
+        self, type_url: str, callback: Callable[[dict[str, Any]], None]
+    ) -> None:
+        """Subscribe to resource updates via SSE.
+
+        Calls ``callback`` with each parsed DiscoveryResponse dict.
+        Runs until the connection drops or the server closes the stream.
+        """
+        url = f"{self._server_url}/xds/v1/{type_url}/subscribe"
+        async with httpx.AsyncClient(timeout=None) as client:
+            async with client.stream("GET", url) as resp:
+                resp.raise_for_status()
+                async for line in resp.aiter_lines():
+                    if line.startswith("data: "):
+                        payload = json.loads(line[6:])
+                        callback(payload)

--- a/src/tessera/xds/resources.py
+++ b/src/tessera/xds/resources.py
@@ -1,0 +1,133 @@
+"""xDS resource types for Tessera policy distribution.
+
+Mirrors the proto definitions in proto/tessera/xds/v1/resources.proto
+as frozen dataclasses. The proto files are the contract; this module
+provides a pure-Python implementation without requiring protobuf
+compilation.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ToolRequirementResource:
+    """A single tool's trust requirement, matching the proto ToolRequirement."""
+
+    name: str
+    resource_type: str
+    required_trust: int
+
+
+@dataclass(frozen=True)
+class PolicyBundleResource:
+    """Policy bundle distributed via xDS, matching the proto PolicyBundle."""
+
+    version: str
+    revision: str
+    requirements: tuple[ToolRequirementResource, ...]
+    default_trust_level: int
+    human_approval_tools: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "revision": self.revision,
+            "requirements": [asdict(r) for r in self.requirements],
+            "default_trust_level": self.default_trust_level,
+            "human_approval_tools": list(self.human_approval_tools),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PolicyBundleResource:
+        return cls(
+            version=data["version"],
+            revision=data["revision"],
+            requirements=tuple(
+                ToolRequirementResource(**r) for r in data.get("requirements", [])
+            ),
+            default_trust_level=data.get("default_trust_level", 100),
+            human_approval_tools=tuple(data.get("human_approval_tools", [])),
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True)
+
+    @classmethod
+    def from_json(cls, raw: str) -> PolicyBundleResource:
+        return cls.from_dict(json.loads(raw))
+
+
+@dataclass(frozen=True)
+class ToolRegistryEntryResource:
+    """A single tool entry, matching the proto ToolRegistryEntry."""
+
+    name: str
+    is_external: bool
+
+
+@dataclass(frozen=True)
+class ToolRegistryResource:
+    """Tool registry distributed via xDS, matching the proto ToolRegistry."""
+
+    version: str
+    revision: str
+    tools: tuple[ToolRegistryEntryResource, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "revision": self.revision,
+            "tools": [asdict(t) for t in self.tools],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ToolRegistryResource:
+        return cls(
+            version=data["version"],
+            revision=data["revision"],
+            tools=tuple(
+                ToolRegistryEntryResource(**t) for t in data.get("tools", [])
+            ),
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True)
+
+    @classmethod
+    def from_json(cls, raw: str) -> ToolRegistryResource:
+        return cls.from_dict(json.loads(raw))
+
+
+@dataclass(frozen=True)
+class TrustConfigResource:
+    """Trust level configuration distributed via xDS, matching the proto TrustConfig."""
+
+    version: str
+    revision: str
+    trust_levels: dict[str, int]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "revision": self.revision,
+            "trust_levels": dict(self.trust_levels),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TrustConfigResource:
+        return cls(
+            version=data["version"],
+            revision=data["revision"],
+            trust_levels=dict(data.get("trust_levels", {})),
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True)
+
+    @classmethod
+    def from_json(cls, raw: str) -> TrustConfigResource:
+        return cls.from_dict(json.loads(raw))

--- a/src/tessera/xds/server.py
+++ b/src/tessera/xds/server.py
@@ -1,0 +1,150 @@
+"""xDS-compatible resource distribution server.
+
+Implements the Aggregated Discovery Service pattern with
+state-of-the-world semantics. Resources are versioned with
+content-addressed hashing (matching the control_plane.py
+revision system).
+
+Uses HTTP/JSON endpoints on the existing FastAPI control plane.
+Subscriptions use Server-Sent Events (SSE) for push updates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import uuid
+from dataclasses import asdict, dataclass
+from typing import Any, AsyncIterator
+
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+
+# Well-known type URLs for Tessera xDS resources.
+TYPE_POLICY_BUNDLE = "type.tessera.dev/tessera.xds.v1.PolicyBundle"
+TYPE_TOOL_REGISTRY = "type.tessera.dev/tessera.xds.v1.ToolRegistry"
+TYPE_TRUST_CONFIG = "type.tessera.dev/tessera.xds.v1.TrustConfig"
+
+
+@dataclass(frozen=True)
+class ResourceWrapper:
+    """Single resource in a discovery response."""
+
+    name: str
+    version: str
+    resource: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class DiscoveryResponse:
+    """State-of-the-world snapshot for a resource type."""
+
+    version_info: str
+    type_url: str
+    resources: tuple[ResourceWrapper, ...]
+    nonce: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version_info": self.version_info,
+            "type_url": self.type_url,
+            "resources": [
+                {"name": r.name, "version": r.version, "resource": r.resource}
+                for r in self.resources
+            ],
+            "nonce": self.nonce,
+        }
+
+
+def _compute_version(resources: dict[str, Any]) -> str:
+    """Content-addressed version derived from all resources of a type."""
+    canonical = json.dumps(resources, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode()).hexdigest()
+    return f"xds-{digest[:16]}"
+
+
+class XDSServer:
+    """xDS resource distribution server.
+
+    Stores resources by type URL and name, tracks versions, and
+    notifies subscribers when resources change.
+    """
+
+    def __init__(self) -> None:
+        self._resources: dict[str, dict[str, dict[str, Any]]] = {}
+        self._versions: dict[str, str] = {}
+        self._subscribers: dict[str, list[asyncio.Queue[DiscoveryResponse]]] = {}
+
+    def set_resource(self, type_url: str, name: str, resource: dict[str, Any]) -> None:
+        """Update a resource and notify subscribers."""
+        if type_url not in self._resources:
+            self._resources[type_url] = {}
+        self._resources[type_url][name] = resource
+        self._versions[type_url] = _compute_version(self._resources[type_url])
+
+        snapshot = self.get_snapshot(type_url)
+        for queue in self._subscribers.get(type_url, []):
+            try:
+                queue.put_nowait(snapshot)
+            except asyncio.QueueFull:
+                pass
+
+    def get_snapshot(self, type_url: str) -> DiscoveryResponse:
+        """Return current state-of-the-world for a resource type."""
+        resources = self._resources.get(type_url, {})
+        version = self._versions.get(type_url, "")
+        wrappers = tuple(
+            ResourceWrapper(name=name, version=version, resource=data)
+            for name, data in sorted(resources.items())
+        )
+        return DiscoveryResponse(
+            version_info=version,
+            type_url=type_url,
+            resources=wrappers,
+            nonce=uuid.uuid4().hex[:16],
+        )
+
+    async def subscribe(self, type_url: str) -> AsyncIterator[DiscoveryResponse]:
+        """Subscribe to resource updates. Yields snapshots on change."""
+        queue: asyncio.Queue[DiscoveryResponse] = asyncio.Queue(maxsize=64)
+        if type_url not in self._subscribers:
+            self._subscribers[type_url] = []
+        self._subscribers[type_url].append(queue)
+        try:
+            while True:
+                response = await queue.get()
+                yield response
+        finally:
+            self._subscribers[type_url].remove(queue)
+
+    def add_to_app(self, app: FastAPI) -> None:
+        """Mount xDS HTTP endpoints on an existing FastAPI app.
+
+        GET  /xds/v1/{type_url:path}           - state of the world
+        GET  /xds/v1/{type_url:path}/subscribe  - SSE stream for deltas
+        """
+        server = self
+
+        @app.get("/xds/v1/{type_url:path}/subscribe")
+        async def xds_subscribe(type_url: str, request: Request) -> StreamingResponse:
+            async def event_stream() -> AsyncIterator[str]:
+                # Send initial snapshot.
+                snapshot = server.get_snapshot(type_url)
+                yield f"data: {json.dumps(snapshot.to_dict())}\n\n"
+                async for update in server.subscribe(type_url):
+                    if await request.is_disconnected():
+                        break
+                    yield f"data: {json.dumps(update.to_dict())}\n\n"
+
+            return StreamingResponse(
+                event_stream(),
+                media_type="text/event-stream",
+                headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+            )
+
+        @app.get("/xds/v1/{type_url:path}")
+        async def xds_fetch(type_url: str) -> dict[str, Any]:
+            snapshot = server.get_snapshot(type_url)
+            return snapshot.to_dict()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,215 @@
+"""Tests for extension hook dispatcher and remote hook client."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from tessera.hooks.client import RemoteHookClient
+from tessera.hooks.dispatcher import HookDispatcher
+from tessera.labels import TrustLevel
+from tessera.policy import Decision, DecisionKind
+
+
+def _allow_decision(tool: str = "send_email") -> Decision:
+    return Decision(
+        kind=DecisionKind.ALLOW,
+        reason="trust met",
+        tool=tool,
+        required_trust=TrustLevel.USER,
+        observed_trust=TrustLevel.USER,
+    )
+
+
+def _deny_decision(tool: str = "send_email") -> Decision:
+    return Decision(
+        kind=DecisionKind.DENY,
+        reason="trust too low",
+        tool=tool,
+        required_trust=TrustLevel.USER,
+        observed_trust=TrustLevel.UNTRUSTED,
+    )
+
+
+# -- HookDispatcher: policy hooks --------------------------------------------
+
+
+def test_dispatcher_runs_policy_hooks() -> None:
+    dispatcher = HookDispatcher()
+    called: list[str] = []
+
+    def hook(tool: str, principal: str, decision: Decision) -> Decision | None:
+        called.append(tool)
+        return None
+
+    dispatcher.register_policy_hook(hook)
+    result = dispatcher.dispatch_policy("send_email", "user@test", _allow_decision())
+    assert result.kind == DecisionKind.ALLOW
+    assert called == ["send_email"]
+
+
+def test_policy_hook_deny_overrides_allow() -> None:
+    dispatcher = HookDispatcher()
+
+    def deny_hook(tool: str, principal: str, decision: Decision) -> Decision | None:
+        return Decision(
+            kind=DecisionKind.DENY,
+            reason="blocked by hook",
+            tool=tool,
+            required_trust=decision.required_trust,
+            observed_trust=decision.observed_trust,
+        )
+
+    dispatcher.register_policy_hook(deny_hook)
+    result = dispatcher.dispatch_policy("send_email", "user@test", _allow_decision())
+    assert result.kind == DecisionKind.DENY
+    assert result.reason == "blocked by hook"
+
+
+def test_policy_hook_cannot_override_deny_to_allow() -> None:
+    dispatcher = HookDispatcher()
+
+    def upgrade_hook(tool: str, principal: str, decision: Decision) -> Decision | None:
+        return Decision(
+            kind=DecisionKind.ALLOW,
+            reason="hook tried to allow",
+            tool=tool,
+            required_trust=decision.required_trust,
+            observed_trust=decision.observed_trust,
+        )
+
+    dispatcher.register_policy_hook(upgrade_hook)
+    result = dispatcher.dispatch_policy("send_email", "user@test", _deny_decision())
+    # The original DENY must survive because hooks are deny-only.
+    assert result.kind == DecisionKind.DENY
+    assert result.reason == "trust too low"
+
+
+def test_policy_hook_error_fails_closed() -> None:
+    dispatcher = HookDispatcher()
+
+    def broken_hook(tool: str, principal: str, decision: Decision) -> Decision | None:
+        raise RuntimeError("boom")
+
+    dispatcher.register_policy_hook(broken_hook)
+    result = dispatcher.dispatch_policy("send_email", "user@test", _allow_decision())
+    assert result.kind == DecisionKind.DENY
+    assert "failing closed" in result.reason
+
+
+# -- HookDispatcher: tool call hooks -----------------------------------------
+
+
+def test_tool_call_hook_allows_on_true() -> None:
+    dispatcher = HookDispatcher()
+
+    def allow_hook(tool: str, args: dict[str, Any], principal: str) -> bool:
+        return True
+
+    dispatcher.register_tool_call_hook(allow_hook)
+    assert dispatcher.dispatch_tool_call("calc", {"x": 1}, "user@test") is True
+
+
+def test_tool_call_hook_blocks_on_false() -> None:
+    dispatcher = HookDispatcher()
+
+    def block_hook(tool: str, args: dict[str, Any], principal: str) -> bool:
+        return False
+
+    dispatcher.register_tool_call_hook(block_hook)
+    assert dispatcher.dispatch_tool_call("calc", {"x": 1}, "user@test") is False
+
+
+def test_tool_call_hook_error_fails_closed() -> None:
+    dispatcher = HookDispatcher()
+
+    def broken_hook(tool: str, args: dict[str, Any], principal: str) -> bool:
+        raise RuntimeError("boom")
+
+    dispatcher.register_tool_call_hook(broken_hook)
+    assert dispatcher.dispatch_tool_call("calc", {}, "user@test") is False
+
+
+# -- RemoteHookClient --------------------------------------------------------
+
+
+def test_remote_hook_client_posts_to_url() -> None:
+    decision = _allow_decision()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"decision_kind": None}
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.post", return_value=mock_response) as mock_post:
+        client = RemoteHookClient("http://hooks.test/evaluate")
+        result = client.post_policy_evaluate("send_email", "user@test", decision)
+
+    assert result is None
+    mock_post.assert_called_once()
+    call_kwargs = mock_post.call_args
+    assert call_kwargs[1]["json"]["tool"] == "send_email"
+    assert call_kwargs[1]["json"]["principal"] == "user@test"
+    assert call_kwargs[1]["json"]["decision_kind"] == "allow"
+
+
+def test_remote_hook_client_deny_override() -> None:
+    decision = _allow_decision()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "decision_kind": "deny",
+        "reason": "remote says no",
+    }
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.post", return_value=mock_response):
+        client = RemoteHookClient("http://hooks.test/evaluate")
+        result = client.post_policy_evaluate("send_email", "user@test", decision)
+
+    assert result is not None
+    assert result.kind == DecisionKind.DENY
+    assert result.reason == "remote says no"
+
+
+def test_remote_hook_client_fails_closed_on_timeout() -> None:
+    decision = _allow_decision()
+
+    with patch("httpx.post", side_effect=httpx.TimeoutException("timed out")):
+        client = RemoteHookClient("http://hooks.test/evaluate", timeout=1.0)
+        result = client.post_policy_evaluate("send_email", "user@test", decision)
+
+    assert result is not None
+    assert result.kind == DecisionKind.DENY
+    assert "failing closed" in result.reason
+
+
+def test_remote_hook_client_fails_closed_on_network_error() -> None:
+    decision = _allow_decision()
+
+    with patch("httpx.post", side_effect=httpx.ConnectError("connection refused")):
+        client = RemoteHookClient("http://hooks.test/evaluate", timeout=1.0)
+        result = client.post_policy_evaluate("send_email", "user@test", decision)
+
+    assert result is not None
+    assert result.kind == DecisionKind.DENY
+    assert "failing closed" in result.reason
+
+
+def test_remote_hook_client_callable_protocol() -> None:
+    """RemoteHookClient is directly registerable as a policy hook."""
+    decision = _allow_decision()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"decision_kind": None}
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.post", return_value=mock_response):
+        client = RemoteHookClient("http://hooks.test/evaluate")
+        dispatcher = HookDispatcher()
+        dispatcher.register_policy_hook(client)
+        result = dispatcher.dispatch_policy("send_email", "user@test", decision)
+
+    assert result.kind == DecisionKind.ALLOW

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1,0 +1,219 @@
+"""Tests for tessera.ir -- intermediate representation for policy config."""
+
+from __future__ import annotations
+
+import pytest
+
+from tessera.ir import (
+    CELRuleIR,
+    PolicyIR,
+    ResourceRequirementIR,
+    compile_policy,
+    from_dict,
+)
+from tessera.labels import TrustLevel
+from tessera.policy import DecisionKind, Policy, ResourceType
+
+
+def test_from_dict_minimal() -> None:
+    """Empty dict produces default PolicyIR."""
+    ir = from_dict({})
+    assert ir == PolicyIR()
+    assert ir.requirements == ()
+    assert ir.scope == "agent"
+    assert ir.default_trust == 100
+    assert ir.cel_rules == ()
+    assert ir.human_approval_tools == frozenset()
+
+
+def test_from_dict_with_requirements() -> None:
+    """Parses tool requirements from the 'requirements' key."""
+    ir = from_dict({
+        "requirements": [
+            {"name": "send_email", "required_trust": 100},
+            {"name": "read_file", "resource_type": "resource", "required_trust": 50},
+        ],
+    })
+    assert len(ir.requirements) == 2
+    assert ir.requirements[0] == ResourceRequirementIR(
+        name="send_email", resource_type="tool", required_trust=100,
+    )
+    assert ir.requirements[1] == ResourceRequirementIR(
+        name="read_file", resource_type="resource", required_trust=50,
+    )
+
+
+def test_from_dict_trust_level_by_name() -> None:
+    """Trust levels resolve from case-insensitive string names."""
+    ir = from_dict({
+        "default_trust": "tool",
+        "requirements": [
+            {"name": "fetch", "required_trust": "user"},
+            {"name": "browse", "required_trust": "UNTRUSTED"},
+        ],
+    })
+    assert ir.default_trust == 50
+    assert ir.requirements[0].required_trust == 100
+    assert ir.requirements[1].required_trust == 0
+
+
+def test_from_dict_trust_level_by_int() -> None:
+    """Trust levels pass through from integer values."""
+    ir = from_dict({
+        "default_trust": 200,
+        "requirements": [
+            {"name": "admin_tool", "required_trust": 200},
+        ],
+    })
+    assert ir.default_trust == 200
+    assert ir.requirements[0].required_trust == 200
+
+
+def test_from_dict_with_cel_rules() -> None:
+    """Parses CEL rule dicts."""
+    ir = from_dict({
+        "cel_rules": [
+            {
+                "name": "block_exfil",
+                "expression": "tool.name == 'send_email'",
+                "action": "deny",
+                "message": "blocked",
+            },
+        ],
+    })
+    assert len(ir.cel_rules) == 1
+    rule = ir.cel_rules[0]
+    assert rule == CELRuleIR(
+        name="block_exfil",
+        expression="tool.name == 'send_email'",
+        action="deny",
+        message="blocked",
+    )
+
+
+def test_from_dict_with_human_approval() -> None:
+    """Parses human approval tool list."""
+    ir = from_dict({
+        "human_approval_tools": ["delete_account", "transfer_funds"],
+    })
+    assert ir.human_approval_tools == frozenset({"delete_account", "transfer_funds"})
+
+
+def test_from_dict_with_scope() -> None:
+    """Parses scope string."""
+    ir = from_dict({"scope": "mesh"})
+    assert ir.scope == "mesh"
+
+
+def test_from_dict_tool_policies_alias() -> None:
+    """The 'tool_policies' key works as an alias for 'requirements'."""
+    ir = from_dict({
+        "tool_policies": [
+            {"name": "query_db", "required_trust": "tool"},
+        ],
+    })
+    assert len(ir.requirements) == 1
+    assert ir.requirements[0].name == "query_db"
+
+
+def test_from_dict_default_required_trust_alias() -> None:
+    """The 'default_required_trust' key works as an alias."""
+    ir = from_dict({"default_required_trust": "system"})
+    assert ir.default_trust == 200
+
+
+def test_from_dict_invalid_trust_name() -> None:
+    """Unknown trust level name raises ValueError."""
+    with pytest.raises(ValueError, match="unknown trust level"):
+        from_dict({"default_trust": "superadmin"})
+
+
+def test_compile_policy_creates_policy() -> None:
+    """IR compiles to a tessera.policy.Policy instance."""
+    ir = PolicyIR()
+    policy = compile_policy(ir)
+    assert isinstance(policy, Policy)
+    assert policy.default_required_trust == TrustLevel.USER
+
+
+def test_compile_policy_with_requirements() -> None:
+    """Requirements are added to the compiled Policy."""
+    ir = PolicyIR(
+        requirements=(
+            ResourceRequirementIR(name="send_email", required_trust=100),
+            ResourceRequirementIR(name="read_file", required_trust=50),
+        ),
+    )
+    policy = compile_policy(ir)
+    assert ("send_email", ResourceType.TOOL) in policy.requirements
+    assert policy.requirements[("send_email", ResourceType.TOOL)].required_trust == TrustLevel.USER
+    assert ("read_file", ResourceType.TOOL) in policy.requirements
+    assert policy.requirements[("read_file", ResourceType.TOOL)].required_trust == TrustLevel.TOOL
+
+
+def test_compile_policy_with_human_approval() -> None:
+    """Human approval tools are registered on the compiled Policy."""
+    ir = PolicyIR(
+        human_approval_tools=frozenset({"delete_account"}),
+    )
+    policy = compile_policy(ir)
+    assert "delete_account" in policy._human_approval_tools
+
+
+def test_compile_policy_default_trust() -> None:
+    """The default trust level propagates to the compiled Policy."""
+    ir = PolicyIR(default_trust=50)
+    policy = compile_policy(ir)
+    assert policy.default_required_trust == TrustLevel.TOOL
+
+
+def test_from_yaml_string_parses_yaml() -> None:
+    """YAML string parses to PolicyIR."""
+    yaml = pytest.importorskip("yaml")  # noqa: F841
+    from tessera.ir import from_yaml_string
+
+    text = """\
+scope: team
+default_trust: tool
+requirements:
+  - name: send_email
+    required_trust: user
+human_approval_tools:
+  - delete_account
+"""
+    ir = from_yaml_string(text)
+    assert ir.scope == "team"
+    assert ir.default_trust == 50
+    assert len(ir.requirements) == 1
+    assert ir.requirements[0].name == "send_email"
+    assert ir.human_approval_tools == frozenset({"delete_account"})
+
+
+def test_round_trip_dict_to_policy() -> None:
+    """dict -> IR -> Policy -> evaluate produces correct decisions."""
+    from tessera.context import Context, make_segment
+    from tessera.labels import Origin, sign_label
+
+    key = b"test-key-for-ir-round-trip"
+
+    ir = from_dict({
+        "default_trust": "user",
+        "requirements": [
+            {"name": "send_email", "required_trust": "user"},
+            {"name": "read_file", "required_trust": "tool"},
+        ],
+    })
+    policy = compile_policy(ir)
+
+    # Build a context at TOOL level.
+    seg = make_segment("tool output", Origin.TOOL, "agent", key)
+    ctx = Context(segments=[seg])
+    assert ctx.min_trust == TrustLevel.TOOL
+
+    # TOOL-level context can call read_file (requires TOOL).
+    decision = policy.evaluate(ctx, "read_file")
+    assert decision.kind == DecisionKind.ALLOW
+
+    # TOOL-level context cannot call send_email (requires USER).
+    decision = policy.evaluate(ctx, "send_email")
+    assert decision.kind == DecisionKind.DENY

--- a/tests/test_policy_backends.py
+++ b/tests/test_policy_backends.py
@@ -10,7 +10,7 @@ import pytest
 from tessera.context import Context, make_segment
 from tessera.events import EventKind, SecurityEvent, clear_sinks, register_sink
 from tessera.labels import Origin, TrustLevel
-from tessera.policy import Policy, ToolRequirement
+from tessera.policy import Policy, ResourceType, ToolRequirement
 from tessera.policy_backends import (
     OPAPolicyBackend,
     PolicyBackendDecision,
@@ -144,19 +144,22 @@ def test_external_policy_input_preserves_base_and_request_required_trust():
             captured["input"] = policy_input.to_dict()
             return PolicyBackendDecision(allow=True)
 
-    base_requirements = {
-        "send_email": ToolRequirement("send_email", TrustLevel.USER),
+    base_requirements_by_name = {
+        "send_email": ToolRequirement("send_email", required_trust=TrustLevel.USER),
+    }
+    base_requirements_keyed = {
+        ("send_email", ResourceType.TOOL): ToolRequirement("send_email", required_trust=TrustLevel.USER),
     }
     policy = Policy(
-        requirements=dict(base_requirements),
+        requirements=dict(base_requirements_keyed),
         default_required_trust=TrustLevel.USER,
         backend=CaptureBackend(),
-        base_requirements=dict(base_requirements),
+        base_requirements=dict(base_requirements_by_name),
     )
     policy.require("send_email", TrustLevel.UNTRUSTED)
     policy.request_requirements["send_email"] = ToolRequirement(
-        "send_email",
-        TrustLevel.UNTRUSTED,
+        name="send_email",
+        required_trust=TrustLevel.UNTRUSTED,
     )
     ctx = _ctx_with(make_segment("email bob", Origin.USER, "alice", KEY))
 

--- a/tests/test_policy_extensions.py
+++ b/tests/test_policy_extensions.py
@@ -1,0 +1,321 @@
+"""Tests for CEL engine, resource-type RBAC, and hierarchical policy merge."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from tessera.context import Context, make_segment
+from tessera.labels import Origin, TrustLevel
+from tessera.policy import (
+    DecisionKind,
+    Policy,
+    PolicyScope,
+    ResourceRequirement,
+    ResourceType,
+    ToolRequirement,
+)
+
+KEY = b"test-hmac-key-do-not-use-in-prod"
+
+try:
+    import celpy  # noqa: F401
+
+    _has_celpy = True
+except ImportError:
+    _has_celpy = False
+
+requires_celpy = pytest.mark.skipif(not _has_celpy, reason="cel-python not installed")
+
+
+def _ctx_with(*segments: object) -> Context:
+    ctx = Context()
+    for s in segments:
+        ctx.add(s)  # type: ignore[arg-type]
+    return ctx
+
+
+# ── CEL engine tests ──────────────────────────────────────────────────
+
+
+@requires_celpy
+def test_cel_rule_denies_when_expression_matches() -> None:
+    from tessera.cel_engine import CELContext, CELPolicyEngine, CELRule
+
+    rule = CELRule(
+        name="block-delete",
+        expression='tool == "delete_account"',
+        action="deny",
+        message="account deletion blocked by CEL",
+    )
+    engine = CELPolicyEngine([rule])
+    cel_ctx = CELContext(
+        tool="delete_account",
+        args={},
+        min_trust=100,
+        principal="alice",
+        segment_count=1,
+        delegation_subject=None,
+        delegation_actions=(),
+    )
+    result = engine.evaluate(cel_ctx)
+    assert result is not None
+    assert result.rule_name == "block-delete"
+    assert result.action == "deny"
+
+
+@requires_celpy
+def test_cel_rule_passes_when_expression_does_not_match() -> None:
+    from tessera.cel_engine import CELContext, CELPolicyEngine, CELRule
+
+    rule = CELRule(
+        name="block-delete",
+        expression='tool == "delete_account"',
+        action="deny",
+        message="account deletion blocked",
+    )
+    engine = CELPolicyEngine([rule])
+    cel_ctx = CELContext(
+        tool="read_file",
+        args={},
+        min_trust=100,
+        principal="alice",
+        segment_count=1,
+        delegation_subject=None,
+        delegation_actions=(),
+    )
+    result = engine.evaluate(cel_ctx)
+    assert result is None
+
+
+@requires_celpy
+def test_cel_require_approval_action() -> None:
+    from tessera.cel_engine import CELContext, CELPolicyEngine, CELRule
+
+    rule = CELRule(
+        name="high-cost-approval",
+        expression="min_trust < 200",
+        action="require_approval",
+        message="requires human sign-off",
+    )
+    engine = CELPolicyEngine([rule])
+    cel_ctx = CELContext(
+        tool="transfer_funds",
+        args={},
+        min_trust=100,
+        principal="alice",
+        segment_count=2,
+        delegation_subject=None,
+        delegation_actions=(),
+    )
+    result = engine.evaluate(cel_ctx)
+    assert result is not None
+    assert result.action == "require_approval"
+
+
+@requires_celpy
+def test_cel_context_includes_delegation_fields() -> None:
+    from tessera.cel_engine import CELContext, CELPolicyEngine, CELRule
+
+    rule = CELRule(
+        name="delegation-check",
+        expression='delegation_subject == "user:bob"',
+        action="deny",
+        message="bob cannot invoke this",
+    )
+    engine = CELPolicyEngine([rule])
+    cel_ctx = CELContext(
+        tool="send_email",
+        args={},
+        min_trust=100,
+        principal="alice",
+        segment_count=1,
+        delegation_subject="user:bob",
+        delegation_actions=("send_email",),
+    )
+    result = engine.evaluate(cel_ctx)
+    assert result is not None
+    assert result.rule_name == "delegation-check"
+
+
+@requires_celpy
+def test_cel_evaluated_after_taint_floor() -> None:
+    """Taint deny takes precedence over CEL evaluation."""
+    from tessera.cel_engine import CELPolicyEngine, CELRule
+
+    rule = CELRule(
+        name="always-deny",
+        expression="true",
+        action="deny",
+        message="should not matter",
+    )
+    engine = CELPolicyEngine([rule])
+    policy = Policy(cel_engine=engine)
+    policy.require("send_email", TrustLevel.USER)
+
+    ctx = _ctx_with(
+        make_segment("untrusted data", Origin.WEB, "alice", KEY),
+    )
+    decision = policy.evaluate(ctx, "send_email")
+    assert decision.kind is DecisionKind.DENY
+    assert "CEL" not in decision.reason
+
+
+@requires_celpy
+def test_cel_engine_raises_without_celpy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CELPolicyEngine raises CELNotAvailable when celpy is missing."""
+    real_celpy = sys.modules.get("celpy")
+    real_celtypes = sys.modules.get("celpy.celtypes")
+    monkeypatch.setitem(sys.modules, "celpy", None)
+    monkeypatch.setitem(sys.modules, "celpy.celtypes", None)
+    import importlib
+    from tessera import cel_engine
+
+    importlib.reload(cel_engine)
+    try:
+        with pytest.raises(cel_engine.CELNotAvailable):
+            cel_engine.CELPolicyEngine([])
+    finally:
+        if real_celpy is not None:
+            monkeypatch.setitem(sys.modules, "celpy", real_celpy)
+        else:
+            monkeypatch.delitem(sys.modules, "celpy", raising=False)
+        if real_celtypes is not None:
+            monkeypatch.setitem(sys.modules, "celpy.celtypes", real_celtypes)
+        else:
+            monkeypatch.delitem(sys.modules, "celpy.celtypes", raising=False)
+        importlib.reload(cel_engine)
+
+
+# ── Resource type tests ───────────────────────────────────────────────
+
+
+def test_resource_requirement_defaults_to_tool() -> None:
+    req = ResourceRequirement(name="send_email")
+    assert req.resource_type is ResourceType.TOOL
+    assert req.required_trust is TrustLevel.USER
+
+
+def test_policy_require_with_resource_type() -> None:
+    policy = Policy()
+    policy.require("my_prompt", TrustLevel.TOOL, resource_type=ResourceType.PROMPT)
+    key = ("my_prompt", ResourceType.PROMPT)
+    assert key in policy.requirements
+    assert policy.requirements[key].resource_type is ResourceType.PROMPT
+
+
+def test_evaluate_with_prompt_resource_type() -> None:
+    policy = Policy()
+    policy.require("summarize", TrustLevel.TOOL, resource_type=ResourceType.PROMPT)
+    ctx = _ctx_with(
+        make_segment("tool output", Origin.TOOL, "alice", KEY),
+    )
+    decision = policy.evaluate(
+        ctx, "summarize", resource_type=ResourceType.PROMPT,
+    )
+    assert decision.allowed
+
+
+def test_evaluate_with_resource_resource_type() -> None:
+    policy = Policy()
+    policy.require("config_file", TrustLevel.USER, resource_type=ResourceType.RESOURCE)
+    ctx = _ctx_with(
+        make_segment("user request", Origin.USER, "alice", KEY),
+    )
+    decision = policy.evaluate(
+        ctx, "config_file", resource_type=ResourceType.RESOURCE,
+    )
+    assert decision.allowed
+
+
+def test_backward_compat_tool_requirement_alias() -> None:
+    """ToolRequirement is an alias for ResourceRequirement."""
+    assert ToolRequirement is ResourceRequirement
+    req = ToolRequirement(name="send_email", required_trust=TrustLevel.USER)
+    assert req.resource_type is ResourceType.TOOL
+
+
+# ── Hierarchical policy tests ────────────────────────────────────────
+
+
+def test_merge_higher_scope_sets_floor() -> None:
+    mesh = Policy(scope=PolicyScope.MESH)
+    mesh.require("deploy", TrustLevel.USER)
+
+    agent = Policy(scope=PolicyScope.AGENT)
+
+    merged = Policy.merge(mesh, agent)
+    ctx = _ctx_with(
+        make_segment("deploy now", Origin.USER, "alice", KEY),
+    )
+    decision = merged.evaluate(ctx, "deploy")
+    assert decision.allowed
+    assert decision.required_trust == TrustLevel.USER
+
+
+def test_merge_agent_cannot_loosen_mesh_policy() -> None:
+    mesh = Policy(scope=PolicyScope.MESH)
+    mesh.require("deploy", TrustLevel.USER)
+
+    agent = Policy(scope=PolicyScope.AGENT)
+    agent.require("deploy", TrustLevel.UNTRUSTED)
+
+    merged = Policy.merge(mesh, agent)
+    key = ("deploy", ResourceType.TOOL)
+    assert merged.requirements[key].required_trust == TrustLevel.USER
+
+
+def test_merge_agent_can_tighten_mesh_policy() -> None:
+    mesh = Policy(scope=PolicyScope.MESH)
+    mesh.require("deploy", TrustLevel.TOOL)
+
+    agent = Policy(scope=PolicyScope.AGENT)
+    agent.require("deploy", TrustLevel.SYSTEM)
+
+    merged = Policy.merge(mesh, agent)
+    key = ("deploy", ResourceType.TOOL)
+    assert merged.requirements[key].required_trust == TrustLevel.SYSTEM
+
+
+def test_merge_unions_human_approval_tools() -> None:
+    mesh = Policy(scope=PolicyScope.MESH)
+    mesh.requires_human_approval("deploy")
+
+    agent = Policy(scope=PolicyScope.AGENT)
+    agent.requires_human_approval("delete_user")
+
+    merged = Policy.merge(mesh, agent)
+    assert "deploy" in merged._human_approval_tools
+    assert "delete_user" in merged._human_approval_tools
+
+
+def test_merge_uses_highest_scope_default_trust() -> None:
+    mesh = Policy(
+        scope=PolicyScope.MESH,
+        default_required_trust=TrustLevel.SYSTEM,
+    )
+    agent = Policy(
+        scope=PolicyScope.AGENT,
+        default_required_trust=TrustLevel.UNTRUSTED,
+    )
+    merged = Policy.merge(mesh, agent)
+    assert merged.default_required_trust == TrustLevel.SYSTEM
+
+
+def test_merge_single_policy_returns_equivalent() -> None:
+    original = Policy(scope=PolicyScope.TEAM)
+    original.require("send_email", TrustLevel.USER)
+    original.requires_human_approval("deploy")
+
+    merged = Policy.merge(original)
+    key = ("send_email", ResourceType.TOOL)
+    assert key in merged.requirements
+    assert merged.requirements[key].required_trust == TrustLevel.USER
+    assert "deploy" in merged._human_approval_tools
+
+
+def test_scope_enum_values() -> None:
+    assert PolicyScope.MESH == "mesh"
+    assert PolicyScope.TEAM == "team"
+    assert PolicyScope.AGENT == "agent"

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,199 @@
+"""Encrypted session persistence tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tessera.events import (
+    EventKind,
+    SecurityEvent,
+    clear_sinks,
+    register_sink,
+)
+from tessera.labels import TrustLevel
+from tessera.policy import Decision, DecisionKind
+from tessera.sessions import PendingApproval, SessionStore, make_session_id
+
+
+@pytest.fixture(autouse=True)
+def _reset_sinks():
+    clear_sinks()
+    yield
+    clear_sinks()
+
+
+def _make_decision(tool: str = "deploy") -> Decision:
+    return Decision(
+        kind=DecisionKind.REQUIRE_APPROVAL,
+        reason="tool requires human approval",
+        tool=tool,
+        required_trust=TrustLevel.USER,
+        observed_trust=TrustLevel.USER,
+    )
+
+
+def _make_approval(
+    tool: str = "deploy",
+    ttl: timedelta = timedelta(minutes=5),
+    session_id: str | None = None,
+) -> PendingApproval:
+    now = datetime.now(timezone.utc)
+    return PendingApproval(
+        session_id=session_id or make_session_id(),
+        tool=tool,
+        principal="alice",
+        decision=_make_decision(tool),
+        context_summary="test context",
+        created_at=now,
+        expires_at=now + ttl,
+    )
+
+
+def _make_expired_approval(tool: str = "deploy") -> PendingApproval:
+    now = datetime.now(timezone.utc)
+    return PendingApproval(
+        session_id=make_session_id(),
+        tool=tool,
+        principal="alice",
+        decision=_make_decision(tool),
+        context_summary="test context",
+        created_at=now - timedelta(minutes=10),
+        expires_at=now - timedelta(minutes=5),
+    )
+
+
+def test_store_and_retrieve():
+    store = SessionStore()
+    approval = _make_approval()
+    sid = store.store(approval)
+    retrieved = store.retrieve(sid)
+    assert retrieved is not None
+    assert retrieved.session_id == sid
+    assert retrieved.tool == "deploy"
+    assert retrieved.principal == "alice"
+    assert retrieved.context_summary == "test context"
+
+
+def test_retrieve_returns_none_for_unknown_id():
+    store = SessionStore()
+    assert store.retrieve("nonexistent-id") is None
+
+
+def test_retrieve_returns_none_for_expired():
+    store = SessionStore()
+    expired = _make_expired_approval()
+    store.store(expired)
+    assert store.retrieve(expired.session_id) is None
+
+
+def test_resolve_approved_returns_allow():
+    store = SessionStore()
+    approval = _make_approval()
+    store.store(approval)
+    decision = store.resolve(
+        approval.session_id, approved=True, approver="bob", reason="lgtm",
+    )
+    assert decision.kind is DecisionKind.ALLOW
+    assert "bob" in decision.reason
+    assert "lgtm" in decision.reason
+
+
+def test_resolve_denied_returns_deny():
+    store = SessionStore()
+    approval = _make_approval()
+    store.store(approval)
+    decision = store.resolve(
+        approval.session_id, approved=False, approver="carol", reason="nope",
+    )
+    assert decision.kind is DecisionKind.DENY
+    assert "carol" in decision.reason
+
+
+def test_resolve_expired_fails_closed():
+    store = SessionStore()
+    expired = _make_expired_approval()
+    store.store(expired)
+    decision = store.resolve(
+        expired.session_id, approved=True, approver="bob", reason="late",
+    )
+    assert decision.kind is DecisionKind.DENY
+    assert "expired" in decision.reason
+
+
+def test_resolve_removes_session():
+    store = SessionStore()
+    approval = _make_approval()
+    store.store(approval)
+    store.resolve(
+        approval.session_id, approved=True, approver="bob",
+    )
+    assert store.retrieve(approval.session_id) is None
+
+
+def test_expire_stale_removes_old_sessions():
+    store = SessionStore()
+    expired = _make_expired_approval()
+    live = _make_approval()
+    store.store(expired)
+    store.store(live)
+    assert len(store) == 2
+    removed = store.expire_stale()
+    assert removed == 1
+    assert len(store) == 1
+    assert store.retrieve(live.session_id) is not None
+
+
+def test_encrypted_store_and_retrieve():
+    key = b"test-encryption-key-32-bytes-ok!"
+    store = SessionStore(encryption_key=key)
+    approval = _make_approval()
+    store.store(approval)
+    retrieved = store.retrieve(approval.session_id)
+    assert retrieved is not None
+    assert retrieved.session_id == approval.session_id
+    assert retrieved.tool == "deploy"
+    assert retrieved.principal == "alice"
+
+
+def test_len_reflects_active_count():
+    store = SessionStore()
+    assert len(store) == 0
+    a1 = _make_approval(tool="t1")
+    a2 = _make_approval(tool="t2")
+    store.store(a1)
+    assert len(store) == 1
+    store.store(a2)
+    assert len(store) == 2
+    store.resolve(a1.session_id, approved=True, approver="x")
+    assert len(store) == 1
+
+
+def test_store_generates_unique_session_ids():
+    a1 = _make_approval()
+    a2 = _make_approval()
+    assert a1.session_id != a2.session_id
+
+
+def test_session_expired_event_fires():
+    events: list[SecurityEvent] = []
+    register_sink(events.append)
+
+    store = SessionStore()
+    expired = _make_expired_approval()
+    store.store(expired)
+    store.expire_stale()
+
+    session_events = [e for e in events if e.kind == EventKind.SESSION_EXPIRED]
+    assert len(session_events) == 1
+    assert session_events[0].detail["session_id"] == expired.session_id
+
+
+def test_resolve_unknown_session_fails_closed():
+    store = SessionStore()
+    decision = store.resolve(
+        "does-not-exist", approved=True, approver="bob",
+    )
+    assert decision.kind is DecisionKind.DENY
+    assert "not found" in decision.reason

--- a/tests/test_xds.py
+++ b/tests/test_xds.py
@@ -1,0 +1,163 @@
+"""Tests for xDS resource distribution server and client."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tessera.xds.resources import (
+    PolicyBundleResource,
+    ToolRegistryEntryResource,
+    ToolRegistryResource,
+    ToolRequirementResource,
+    TrustConfigResource,
+)
+from tessera.xds.server import (
+    TYPE_POLICY_BUNDLE,
+    TYPE_TOOL_REGISTRY,
+    XDSServer,
+)
+
+
+# -- Resource serialization --------------------------------------------------
+
+
+def test_policy_bundle_resource_serialization() -> None:
+    bundle = PolicyBundleResource(
+        version="1",
+        revision="rev-abc",
+        requirements=(
+            ToolRequirementResource(name="send_email", resource_type="tool", required_trust=100),
+        ),
+        default_trust_level=50,
+        human_approval_tools=("delete_account",),
+    )
+    as_dict = bundle.to_dict()
+    roundtripped = PolicyBundleResource.from_dict(as_dict)
+    assert roundtripped == bundle
+
+    as_json = bundle.to_json()
+    from_json = PolicyBundleResource.from_json(as_json)
+    assert from_json == bundle
+
+
+def test_tool_registry_resource_serialization() -> None:
+    registry = ToolRegistryResource(
+        version="1",
+        revision="rev-def",
+        tools=(
+            ToolRegistryEntryResource(name="web_search", is_external=True),
+            ToolRegistryEntryResource(name="calculator", is_external=False),
+        ),
+    )
+    as_dict = registry.to_dict()
+    roundtripped = ToolRegistryResource.from_dict(as_dict)
+    assert roundtripped == registry
+
+    as_json = registry.to_json()
+    from_json = ToolRegistryResource.from_json(as_json)
+    assert from_json == registry
+
+
+def test_trust_config_resource_serialization() -> None:
+    config = TrustConfigResource(
+        version="1",
+        revision="rev-ghi",
+        trust_levels={"user": 100, "tool": 50, "untrusted": 0},
+    )
+    as_dict = config.to_dict()
+    roundtripped = TrustConfigResource.from_dict(as_dict)
+    assert roundtripped == config
+
+
+# -- XDSServer unit tests ----------------------------------------------------
+
+
+def test_xds_server_set_and_get_resource() -> None:
+    server = XDSServer()
+    resource = {"name": "test-policy", "default_trust_level": 100}
+    server.set_resource(TYPE_POLICY_BUNDLE, "default", resource)
+
+    snapshot = server.get_snapshot(TYPE_POLICY_BUNDLE)
+    assert len(snapshot.resources) == 1
+    assert snapshot.resources[0].name == "default"
+    assert snapshot.resources[0].resource == resource
+    assert snapshot.version_info != ""
+
+
+def test_xds_server_version_increments_on_update() -> None:
+    server = XDSServer()
+    server.set_resource(TYPE_POLICY_BUNDLE, "default", {"v": 1})
+    v1 = server.get_snapshot(TYPE_POLICY_BUNDLE).version_info
+
+    server.set_resource(TYPE_POLICY_BUNDLE, "default", {"v": 2})
+    v2 = server.get_snapshot(TYPE_POLICY_BUNDLE).version_info
+
+    assert v1 != v2, "Version must change when resource content changes"
+
+
+def test_xds_server_version_stable_for_same_content() -> None:
+    server = XDSServer()
+    server.set_resource(TYPE_POLICY_BUNDLE, "default", {"v": 1})
+    v1 = server.get_snapshot(TYPE_POLICY_BUNDLE).version_info
+
+    # Set same content again.
+    server.set_resource(TYPE_POLICY_BUNDLE, "default", {"v": 1})
+    v2 = server.get_snapshot(TYPE_POLICY_BUNDLE).version_info
+
+    assert v1 == v2, "Version must be stable for identical content"
+
+
+# -- HTTP endpoint tests (via TestClient) ------------------------------------
+
+
+def _make_app_with_xds() -> tuple[FastAPI, XDSServer]:
+    app = FastAPI()
+    server = XDSServer()
+    server.add_to_app(app)
+    return app, server
+
+
+def test_xds_server_fetch_resources_returns_snapshot() -> None:
+    app, server = _make_app_with_xds()
+    server.set_resource(TYPE_POLICY_BUNDLE, "default", {"trust": 100})
+
+    client = TestClient(app)
+    resp = client.get(f"/xds/v1/{TYPE_POLICY_BUNDLE}")
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert body["type_url"] == TYPE_POLICY_BUNDLE
+    assert len(body["resources"]) == 1
+    assert body["resources"][0]["name"] == "default"
+    assert body["resources"][0]["resource"]["trust"] == 100
+    assert body["version_info"] != ""
+    assert body["nonce"] != ""
+
+
+def test_xds_client_fetch_from_server() -> None:
+    """Use TestClient as a stand-in for httpx to verify the fetch path."""
+    app, server = _make_app_with_xds()
+    server.set_resource(TYPE_TOOL_REGISTRY, "tools", {"tools": ["a", "b"]})
+
+    client = TestClient(app)
+    resp = client.get(f"/xds/v1/{TYPE_TOOL_REGISTRY}")
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert body["type_url"] == TYPE_TOOL_REGISTRY
+    assert len(body["resources"]) == 1
+    assert body["resources"][0]["resource"]["tools"] == ["a", "b"]
+
+
+def test_xds_fetch_empty_type_returns_empty_resources() -> None:
+    app, _server = _make_app_with_xds()
+    client = TestClient(app)
+    resp = client.get("/xds/v1/unknown.type")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["resources"] == []
+    assert body["version_info"] == ""


### PR DESCRIPTION
## Summary

Nine infrastructure initiatives ported from agentgateway and Envoy Gateway patterns:

From agentgateway:
- CEL expression engine for policy rules (deny-only refinements via cel-python)
- MCP RBAC per-resource authorization (TOOL, PROMPT, RESOURCE types)
- Rust gateway filter pipeline architecture (Filter trait, FilterChain, 4 extracted filters)
- Session persistence with Fernet encryption for approval workflows
- SecretString credential management with file-watching rotation in Rust gateway

From Envoy Gateway:
- xDS-compatible resource distribution (PolicyBundle, ToolRegistry, TrustConfig) with SSE subscriptions
- Hierarchical policy targeting (MESH > TEAM > AGENT scopes, merge prevents loosening)
- Extension server hooks (deny-only HookDispatcher, RemoteHookClient)
- IR abstraction layer (PolicyIR compiles to live Policy from any input format)

## Test plan

- [x] 344 Python tests passed, 6 skipped (CEL without cel-python)
- [x] 45 Rust tests passed (up from 40, filter chain adds 5)
- [x] All existing tests pass unchanged (backward compatible)
- [x] No load-bearing invariants modified
- [x] Taint floor remains primary, all extensions are deny-only refinements