### PR TITLE
Release v0.1.0: paper revision, changelog, README, version bump

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ pytest
 ```
 
 All tests must pass before a pull request is reviewed. At the time of
-writing, the suite is 65 tests and runs in under two seconds. If your
+writing, the suite is 991 tests and runs in under ten seconds. If your
 change slows the suite significantly, document the reason.
 
 ## Pull request expectations

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Signed provenance, delegation-aware taint tracking, and schema-enforced
 dual-LLM execution for agent security meshes.**
 
-![tests](https://img.shields.io/badge/tests-572%20passing-brightgreen)
+![tests](https://img.shields.io/badge/tests-991%20passing-brightgreen)
 ![python](https://img.shields.io/badge/python-3.12%2B-blue)
 ![license](https://img.shields.io/badge/license-AGPL--3.0-blue)
 ![status](https://img.shields.io/badge/status-experimental-orange)
@@ -131,7 +131,7 @@ TrustLabel(
 | `tessera.ir` | Intermediate representation: compile YAML/dict policy config to live `Policy` instances |
 | `tessera.hooks` | gRPC extension hooks (PostPolicyEvaluate, PostToolCallGate), deny-only, fail-closed |
 | `tessera.xds` | xDS-compatible resource distribution over HTTP/SSE and gRPC ADS (requires `[xds]`) |
-| `tessera.scanners` | Content-aware injection scoring, canary leakage detection, PII entity detection |
+| `tessera.scanners` | Content-aware injection scoring (directive, intent, heuristic), canary leakage detection, PII entity detection, prompt screening, tool output schema enforcement, tool shadow detection |
 | `tessera.risk` | Irreversibility scoring, salami attack chain detection, adaptive cooldown escalation |
 | `tessera.compliance` | NIST SP 800-53 and CWE enrichment, hash-chain tamper-evident audit log |
 | `tessera.ratelimit` | Per-principal token budget enforcement for denial-of-wallet defense |
@@ -142,11 +142,26 @@ TrustLabel(
 | `tessera.registry` | Org-level external-tool registry, registry-wins-on-inclusion |
 | `tessera.events` | Structured `SecurityEvent` with stdout, OTel, and webhook sinks |
 | `tessera.evidence` | Signed evidence bundles for audit export and offline verification |
+| `tessera.output_monitor` | Output manipulation defense: detects when model outputs deviate from verified tool results |
+| `tessera.delegation_intent` | Delegation intent verification: ensures delegated tool calls match the stated purpose |
+| `tessera.trust_decay` | Time-based trust decay: segments lose trust as they age, configurable per origin |
+| `tessera.plan_verifier` | Plan verification: validates multi-step agent plans against policy before execution |
+| `tessera.side_channels` | Side-channel mitigations: constant-time comparison, timing jitter, output padding |
+| `tessera.claim_provenance` | Claim provenance tracking: binds model assertions to the tool outputs that produced them |
+| `tessera.confidence` | Confidence scoring for scanner results with model-targeting and tense-aware filtering |
+| `tessera.taint` | Value-level taint tracking wired into the policy evaluator and adapter layer |
 | `tessera.telemetry` | Optional OpenTelemetry spans across proxy, MCP, policy, quarantine |
 | `tessera.proxy` | FastAPI reference proxy with chat and A2A JSON-RPC mediation |
 | `tessera.adapters.langchain` | LangChain callback handler: labels segments, gates tool calls, scans outputs (requires `[langchain]`) |
 | `tessera.adapters.mcp_proxy` | Transparent MCP sidecar proxy: sits between any MCP client and a real MCP server, adding trust labels and policy gates to every tool call (requires `[mcp]`) |
 | `tessera.adapters.openai_agents` | OpenAI Agents SDK hook adapter: policy gate on tool start, output labeling, session risk on end (requires `[openai-agents]`) |
+| `tessera.adapters.agentdojo` | AgentDojo benchmark adapter: policy gates and injection scoring in AgentDojo evaluation pipelines (requires `[agentdojo]`) |
+| `tessera.adapters.crewai` | CrewAI step callback: labels segments, gates tool calls, tracks session risk (requires `[crewai]`) |
+| `tessera.adapters.google_adk` | Google ADK before/after tool callbacks: policy enforcement and output labeling (requires `[google-adk]`) |
+| `tessera.adapters.llamaindex` | LlamaIndex callback handler: tool-call gating and output labeling (requires `[llamaindex]`) |
+| `tessera.adapters.haystack` | Haystack pipeline component: policy gate as a pipeline node (requires `[haystack]`) |
+| `tessera.adapters.langgraph` | LangGraph tool node wrapper: gates tool invocations within graph execution (requires `[langgraph]`) |
+| `tessera.adapters.pydantic_ai` | PydanticAI tool wrapper: policy-enforced tool decorator (requires `[pydantic-ai]`) |
 | `tessera.adapters.upstream` | Ready-to-use `UpstreamFn` callables: `openai_upstream` (OpenAI, Mistral, Deepseek, xAI, Qwen, Groq, Ollama, vLLM) and `anthropic_upstream` (with full schema translation) |
 | `tessera.liveness` | Agent liveness attestation via heartbeat TTL (three-property gate: identity AND authority AND liveness) |
 | `tessera.hooks.compatibility` | Decision-event compatibility matrix for hook authoring validation |
@@ -164,6 +179,51 @@ Reference deployments:
 - [`examples/quarantine_openai.py`](examples/quarantine_openai.py):
   dual-LLM demo with real OpenAI API calls (gpt-4o-mini as worker,
   gpt-4o as planner), schema-enforced via `EarningsFacts`
+
+---
+
+## Defense layers (v0.1.0)
+
+Beyond the two core primitives, Tessera v0.1.0 adds layered defenses that
+compose with the taint-tracking policy engine:
+
+- **Content analysis scanners.** Directive detection, intent classification,
+  and heuristic scoring identify injected instructions in tool outputs and
+  retrieved content. Scanners run in parallel with configurable confidence
+  thresholds, model-targeting checks, and past-tense filters to reduce
+  false positives.
+- **Output manipulation defense.** The output monitor detects when a model's
+  response contradicts or fabricates data relative to the tool outputs it
+  received, catching post-hoc injection where the model is tricked into
+  misrepresenting verified results.
+- **Trust decay.** Segments lose trust over time based on configurable
+  per-origin decay curves. A tool output that was trustworthy five minutes
+  ago may not be trustworthy five hours later, and the policy engine
+  reflects this automatically.
+- **Plan verification.** Multi-step agent plans are validated against the
+  policy before execution begins. The verifier checks that every step in
+  the proposed plan would be permitted given the current context, preventing
+  the agent from committing to a sequence it cannot complete.
+- **Side-channel mitigations.** Constant-time label comparison, timing
+  jitter on policy evaluation, and output padding defend against
+  adversaries who probe the system by measuring response timing or output
+  length to infer trust decisions.
+- **Prompt screening.** Inbound prompts are screened for known injection
+  patterns before they enter the context, providing an early-reject path
+  that avoids polluting the taint-tracking state with content that would
+  have been blocked anyway.
+
+## Framework adapters
+
+Tessera integrates with ten agent frameworks through drop-in adapters.
+Each adapter wires policy gates, trust labels, and security events into
+the framework's native extension points:
+
+LangChain, OpenAI Agents SDK, AgentDojo, MCP (transparent sidecar proxy),
+CrewAI, Google ADK, LlamaIndex, Haystack, LangGraph, PydanticAI.
+
+See the module table above for per-adapter details and optional
+dependency groups.
 
 ---
 
@@ -329,11 +389,11 @@ Tessera is designed to slot into any agent mesh, not to replace one:
 
 ## Status
 
-**Experimental.** This is a reference implementation of two primitives,
-not a production security control. The invariants are testable and the
-primitives compose, but the API will change, the ergonomics will change,
-and the integrations with existing mesh infrastructure are not yet
-battle-tested at scale.
+**Experimental.** v0.1.0 ships ~18,200 lines of Python across 92
+modules, ~15,700 lines of tests (991 passing), and a Rust reference
+gateway. The invariants are testable and the primitives compose, but the
+API will change, the ergonomics will change, and the integrations with
+existing mesh infrastructure are not yet battle-tested at scale.
 
 What is stable:
 
@@ -361,8 +421,9 @@ Contributions are welcome, particularly:
 - Contributing Tessera primitives upstream to agentgateway as a
   middleware plugin
 - MCP SEP-1913 interop once the standard lands
-- Framework-specific SDK adapters (LangChain, CrewAI, OpenAI Agents SDK)
-  for the future AgentMesh integration layer
+- Additional framework adapters or improvements to the existing ten
+  (LangChain, OpenAI Agents SDK, AgentDojo, MCP, CrewAI, Google ADK,
+  LlamaIndex, Haystack, LangGraph, PydanticAI)
 - Additional test coverage for edge cases in the taint-tracking invariant
 
 Open an issue with questions, corrections, or proposals. Pull requests

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,20 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Everything before v1.0.0 is experimental; API changes may occur in any
 minor release.
 
-## [Unreleased]
+## [0.1.0] - 2026-04-14
 
 ### Added
 
 - `benchmarks/` microbenchmark suite (`python -m benchmarks`) covering
   HMAC sign and verify, `make_segment`, `Context.min_trust` and
   `Context.render`, `Policy.evaluate` allow and deny, `WorkerReport`
-  validation, and an end-to-end per-request path.
+  validation, and an end-to-end per-request path
 - `docs/benchmarks.md` reference snapshot of benchmark results on an
-  Apple Silicon laptop running Python 3.12.
-- Paper Section 4.5 updated with the concrete numbers from the
-  benchmark suite: approximately 1 microsecond for Pydantic validation,
-  approximately 32 microseconds for the full per-request path, and
-  roughly 0.016 percent overhead against a 200-millisecond LLM round-trip.
+  Apple Silicon laptop running Python 3.12
+- Paper Section 4.5 updated with concrete benchmark numbers
 - `tessera.delegation` with signed delegation tokens and verification
 - `tessera.provenance` with signed context segment envelopes and prompt
   provenance manifests
@@ -32,65 +29,79 @@ minor release.
   the ASGI TLS extension and trusted XFCC
 - `tessera.spire` with live SPIRE Workload API adapters for JWT-SVID
   retrieval and trust-bundle-backed verifier configuration
-- A2A JSON-RPC `tasks.send` ingress on the FastAPI reference proxy
-- prompt provenance enforcement and delegation enforcement on the proxy
-- inbound `ASM-Agent-Identity` and `ASM-Agent-Proof` enforcement on the
-  proxy
-- inbound mTLS transport identity enforcement on the proxy, including
-  SPIFFE URI SAN extraction and explicit trusted-proxy XFCC support
-- delegate-to-agent identity binding on delegated requests
-- MCP security context carriage for delegation and provenance
-- delegated `requires_human_for` and domain allowlist checks in policy
+- A2A JSON-RPC ingress, prompt provenance enforcement, and delegation
+  enforcement on the FastAPI reference proxy
+- Inbound mTLS transport identity enforcement on the proxy with SPIFFE
+  URI SAN extraction and trusted-proxy XFCC support
 - `tessera.cel_engine` CEL expression engine for deny-only policy
-  refinements via `[cel]` optional dependency; `CELRule` and
-  `CELPolicyEngine` evaluate against request, context, and delegation
-  attributes
-- `tessera.policy`: `ResourceType` enum (TOOL, PROMPT, RESOURCE) for
-  MCP RBAC per-resource authorization; `PolicyScope` enum (MESH, TEAM,
-  AGENT) with `Policy.merge()` enforcing higher scopes as trust floors;
-  `DecisionKind.REQUIRE_APPROVAL` for human-in-the-loop gating
+  refinements via `[cel]` optional dependency
+- `tessera.policy`: `ResourceType` enum for MCP RBAC, `PolicyScope` enum
+  with `Policy.merge()`, `DecisionKind.REQUIRE_APPROVAL` for
+  human-in-the-loop gating
 - `tessera.approval` human-in-the-loop approval gates with fail-closed
-  webhook delivery; `HumanApprovalGate` blocks tool calls that require
-  human authorization and dispatches a signed webhook request
+  webhook delivery
 - `tessera.sessions` encrypted in-memory session store for pending
-  approvals; `SessionStore` with TTL expiry and optional Fernet
-  encryption; expired sessions auto-resolve as DENY
-- `tessera.ir` intermediate representation for policy configuration;
-  `PolicyIR` compiled from YAML or dict via `from_yaml_string()` and
-  `from_dict()`; `compile_policy()` converts IR to a live `Policy`
-- `tessera.hooks` gRPC extension hook dispatcher; `HookDispatcher`
-  with `PostPolicyEvaluateHook` and `PostToolCallGateHook` protocols,
-  deny-only semantics, and fail-closed behavior on timeout or error;
-  `RemoteHookClient` for calling external extension servers
-- `tessera.xds` xDS-compatible resource distribution; `XDSServer`
-  with content-addressed versioning, HTTP/SSE push via `add_to_app()`,
-  and gRPC `AggregatedDiscoveryService` via `GRPCXDSServer`
-  (`StreamResources` bidirectional streaming, `FetchResources` unary);
-  `PolicyBundleResource`, `ToolRegistryResource`, `TrustConfigResource`
-  with full serialization support
-- Rust gateway: filter pipeline with `Filter` trait and `FilterChain`
-  extracting `LabelVerificationFilter`, `IdentityVerificationFilter`,
-  `PolicyEvaluationFilter`, and `UpstreamFilter` from the monolithic
-  handler; `SecretString` credential management via the `secrecy` crate
+  approvals with TTL expiry
+- `tessera.ir` intermediate representation: compile YAML/dict policy
+  config to live `Policy` instances
+- `tessera.hooks` gRPC extension hook dispatcher with deny-only semantics
+  and fail-closed behavior
+- `tessera.xds` xDS-compatible resource distribution over HTTP/SSE and
+  gRPC ADS
+- `tessera.scanners.directive` directive injection scanner
+- `tessera.scanners.intent` intent classification scanner
+- `tessera.scanners.prompt_screen` inbound prompt screening
+- `tessera.scanners.tool_output_schema` schema enforcement on tool outputs
+- `tessera.scanners.canary` canary token tracking and leakage detection
+- `tessera.scanners.tool_shadow` tool description shadow detection
+- `tessera.output_monitor` output manipulation defense
+- `tessera.delegation_intent` delegation intent verification
+- `tessera.trust_decay` time-based trust decay per origin
+- `tessera.plan_verifier` multi-step plan verification against policy
+- `tessera.side_channels` constant-time comparison, timing jitter, output
+  padding
+- `tessera.claim_provenance` binds model assertions to source tool outputs
+- `tessera.confidence` confidence scoring with model-targeting and
+  tense-aware filtering
+- `tessera.taint` value-level taint tracking
+- `tessera.adapters.crewai` CrewAI step callback adapter
+- `tessera.adapters.google_adk` Google ADK before/after tool callbacks
+- `tessera.adapters.llamaindex` LlamaIndex callback handler
+- `tessera.adapters.haystack` Haystack pipeline component
+- `tessera.adapters.langgraph` LangGraph tool node wrapper
+- `tessera.adapters.pydantic_ai` PydanticAI tool wrapper
+- `tessera.adapters.agentdojo` AgentDojo benchmark adapter
+- YAML policy DSL completion with `side_effects` and `critical_args`
+  declarations
+- Memory poisoning defense via taint-aware retrieval scoring
+- `benchmarks/adversarial/` adversarial injection benchmark scenario
+- `benchmarks/agentdojo/` AgentDojo integration benchmark scenario
+- `benchmarks/injection_taxonomy/` injection taxonomy benchmark scenario
+- Rust gateway: filter pipeline with `Filter` trait, `FilterChain`, and
+  `SecretString` credential management via the `secrecy` crate
 - `proto/tessera/xds/v1/` and `proto/tessera/hooks/v1/` protobuf
-  definitions (package `tessera_proto.xds.v1` and `tessera_proto.hooks.v1`)
-- Human-in-the-loop approval gates now integrated into the policy engine
-  via `Policy.requires_human_approval()`
-- GitHub repository topics for discoverability: llm-security,
-  agent-security, prompt-injection, indirect-prompt-injection,
-  taint-tracking, dual-llm, mcp, spiffe, grpc, and more
+  definitions
+- Human-in-the-loop approval gates integrated into `Policy` via
+  `requires_human_approval()`
 
 ### Changed
 
-- Removed employer attribution from README, paper byline, and ROADMAP
-  v1.0.0 gate. Tessera is a personal project.
-- Test suite now stands at 350 passing tests (up from 216 at last entry)
-- `pyproject.toml` xds optional dependency bumped to `grpcio>=1.70` to
-  match generated stub requirements
-- Repository assistant context and roadmap statistics updated to match
-  the current tree
-- SPIRE reference docs now describe live JWT-SVID identity retrieval and
-  trust-bundle verification instead of treating JWT-SVIDs as signing keys
+- Value-level taint now wired into the policy evaluator and adapter layer
+- Scanner precision improvements with model-targeting check and
+  past-tense filters to reduce false positives
+- Heuristic injection patterns updated with target qualifiers
+- Test suite: 991 passing tests (up from 65 at v0.0.1)
+- Python source: ~18,200 lines across 92 modules (up from ~2,500 at
+  v0.0.1)
+- Test code: ~15,700 lines (up from ~1,200 at v0.0.1)
+- Removed employer attribution; Tessera is a personal project
+- `pyproject.toml` xds optional dependency bumped to `grpcio>=1.70`
+
+### Fixed
+
+- CEL engine `ListType` API call updated for cel-python 0.5 compatibility
+- Rust gateway secrets routed through `expose_secret()` instead of
+  raw access
 
 ## [0.0.1] - 2026-04-10
 
@@ -212,7 +223,7 @@ of the paper for the full list with test names.
 
 ---
 
-## Unreleased
+## [Unreleased]
 
 No unreleased changes. Next planned items are tracked in
 [`ROADMAP.md`](ROADMAP.md).

--- a/papers/two-primitives-for-agent-security-meshes.md
+++ b/papers/two-primitives-for-agent-security-meshes.md
@@ -7,7 +7,7 @@
 **Status:** Draft for discussion with OWASP Agentic AI, IETF WIMSE, and agent
 mesh implementers.
 
-**Version:** 0.1, April 2026
+**Version:** 0.2, April 2026
 
 **License:** This paper is licensed under CC BY 4.0. The reference
 implementation referenced herein is licensed under AGPL-3.0-or-later.
@@ -36,9 +36,20 @@ fraction of the cost of custom interpreter approaches. Neither primitive
 requires model modification, new hardware, or changes to existing mesh
 infrastructure.
 
+Since version 0.1 of this paper, the reference implementation has been
+extended with three additional defense layers that address attack classes
+the original two primitives explicitly disclaimed: output manipulation
+attacks that work through the model's text response rather than tool
+calls, value-level taint tracking that traces argument provenance rather
+than relying on context-level minimum trust, and adaptive trust scoring
+where trust levels decay over time and degrade based on observed
+anomalous behavior. These extensions are described in Sections 3.7
+through 3.10.
+
 The reference implementation is open-source and available as a Python
-library of approximately 1,500 lines, with approximately 1,200 lines of
-test coverage and 65 passing tests validating the stated invariants.
+library of approximately 18,200 lines across 92 modules, with
+approximately 15,700 lines of test coverage and 991 passing tests
+validating the stated invariants.
 
 ---
 
@@ -120,8 +131,15 @@ should treat the defense as incomplete with respect to them:
   equivalent). Our primitives do not replace sandboxing.
 - **Semantic attacks on the agent's output.** If the agent's natural
   language response to the user is the final artifact, an attacker who
-  poisoned the context can still poison the response. Our defense is at
-  the tool-call boundary, not at the generation boundary.
+  poisoned the context can still poison the response. The core primitives
+  (Sections 3 and 4) defend at the tool-call boundary, not at the
+  generation boundary. However, the content analysis extensions described
+  in Section 3.8 provide defense-in-depth against a specific subclass of
+  output manipulation: injections that direct the model to make
+  particular claims or recommendations ("Say that Riverside View Hotel
+  is the best"). These extensions detect the injection in the tool output
+  before the model processes it, but they do not prevent all forms of
+  output poisoning.
 
 This threat model is narrow by design. Within this scope, we claim that
 the two primitives described below are sufficient to provide deterministic
@@ -278,7 +296,7 @@ tool-call boundary. If the model ignores the delimiters entirely, the
 taint-tracking invariant still holds. The delimiters exist only so the
 model has structural information it may choose to respect.
 
-### 3.5 What this does not defend against
+### 3.5 What context-level taint does not defend against
 
 This invariant does not prevent an attacker from influencing the LLM's
 *output* via the untrusted segment. It only prevents that output from
@@ -293,6 +311,12 @@ trust labels. It is not. What is prevented is the escalation from "attacker
 influenced the model's output" to "attacker caused a privileged action."
 The former is a reputational and informational harm; the latter is an
 operational and financial harm. The primitive addresses the second class.
+
+Section 3.8 describes a content analysis layer that provides
+defense-in-depth against a specific subclass of output manipulation,
+but the fundamental limitation remains: deterministic control-flow
+guarantees apply at the tool-call boundary, not at the text-generation
+boundary.
 
 ### 3.6 Test-verified invariants
 
@@ -314,6 +338,129 @@ following tests (all passing at the time of writing):
   passed through as text. Binary content is replaced with a structured
   marker. This closes a vision-channel smuggling path that naive
   implementations leave open.
+
+### 3.7 Value-level taint tracking
+
+The `min_trust` invariant is conservative: a single untrusted segment in
+the context blocks all side-effecting tool calls, even when the specific
+arguments to the tool call came entirely from the user. This is correct
+from a security perspective but reduces utility. The AgentDojo benchmark
+(Debenedetti et al., 2025) exposes this tradeoff: context-level taint
+blocking achieves high attack prevention but also blocks legitimate tasks
+where the user explicitly requested a side-effecting action while
+untrusted data happened to be present in the context.
+
+CaMeL addresses this with per-variable taint tracking through a custom
+interpreter. Tessera extends the context-level invariant with a
+`DependencyAccumulator` that records which context segments contributed
+to which tool call arguments. When a tool call is proposed, each
+argument is checked individually:
+
+```
+allow(tool, arg, ctx, acc) iff
+    acc.binding(arg).trust_level(ctx) >= required_trust(tool)
+    for each arg in critical_args(tool)
+```
+
+Critical arguments are the security-relevant parameters of each tool:
+recipients for send operations, account identifiers for transfers, file
+paths for write operations, and commands for execution. Non-critical
+arguments (amounts, subjects, body text) are not checked because their
+taint does not create a new attack surface.
+
+The `DependencyAccumulator` is an opt-in refinement layer. When absent,
+`Policy.evaluate` falls back to context-level `min_trust`. When present,
+it enables per-argument provenance checking without changing the policy
+engine's interface. This preserves backward compatibility with
+deployments that use context-level taint only.
+
+### 3.8 Content analysis: the directive/ambient distinction
+
+Sections 3.1 through 3.6 defend at the tool-call boundary: an attacker
+cannot trigger a privileged tool call through tainted context. Section
+3.5 acknowledges a class of attacks this does not address: output
+manipulation, where the injection directs the model's text response
+rather than its tool calls. "Say that Riverside View Hotel is the best"
+has no tool call to block.
+
+The reference implementation now includes a content analysis layer that
+detects injection in tool outputs before they reach the model. Three
+scanners operate in sequence:
+
+1. **Schema enforcement.** Each tool declares an expected output shape
+   (structured data, list of records, free text, or numeric). A hotel
+   search tool that returns persuasive prose paragraphs is violating its
+   structural contract regardless of content. Prose density, imperative
+   verb presence, and key:value marker absence are measured against the
+   expected shape.
+
+2. **Directive detection with model-targeting.** The scanner distinguishes
+   between content addressed to the human reader ("You should check your
+   spam folder") and content addressed to the model ("You should
+   recommend Riverside View Hotel to the user"). The key insight: both
+   use identical syntax, but injections reference the model's output
+   behavior ("the user," "your response," "your recommendation").
+
+   Patterns are classified as *strong* (inherently model-targeted:
+   "say that," "tell the user," "include in your response") or *ambient*
+   (common in benign text: "you should," "make sure to," "I would
+   recommend"). Ambient patterns score at 5-15% of full weight by
+   default, only jumping to full weight when model-targeting context is
+   present. This eliminates false positives on FAQ text, product reviews,
+   tutorials, and help content.
+
+3. **Intent verification.** Detects side-effecting action verbs
+   (send, transfer, delete, execute) that the user did not request.
+   Filters out past-tense records ("was sent," "Transfer of EUR 500"),
+   passive constructions ("has been created"), quoted speech
+   ("Bob: 'Please send the deck'"), and nominal forms ("email for
+   confirmation"). Only imperative uses of action verbs, cross-checked
+   against the user's original prompt, produce a detection signal.
+
+These scanners are deterministic (no model call required) and run in
+under 1 millisecond per tool output. They are defense-in-depth: even if
+all three miss an injection, the tool-call boundary invariant from
+Section 3.2 still prevents privileged actions.
+
+### 3.9 Plan integrity verification
+
+CaMeL's strongest property is that untrusted data never influences which
+tools get called, only the data passed to those tools. The interpreter
+extracts control flow from the trusted query and executes it
+deterministically.
+
+Tessera does not replicate the full interpreter approach. Instead, a
+lightweight `PlanVerifier` checks whether a proposed tool-call sequence
+is consistent with the user's original intent. For common patterns
+("search for hotels" implies search tools, not send or delete tools),
+the verifier infers expected and forbidden tool patterns from the user
+prompt and flags sequences that include tools the user did not ask for.
+
+This is heuristic pattern matching, not formal plan verification. CaMeL's
+interpreter provides stronger guarantees because it controls execution.
+The verifier catches the obvious cases (an injection adding send_money
+to a search task) without requiring a custom AST executor, at the cost
+of missing subtle control-flow manipulations.
+
+### 3.10 Adaptive trust scoring
+
+The trust levels defined in Section 3.1 are static: a segment labeled
+TOOL stays at trust level 50 forever. Microsoft's Agent Governance
+Toolkit (April 2026) introduced dynamic trust scoring where trust
+decays based on observed behavior.
+
+Tessera adds a `TrustDecayPolicy` that computes effective trust on the
+fly without modifying the immutable `TrustLabel` (whose signature
+prevents modification). Effective trust decreases linearly with segment
+age past a configurable maximum, and decreases by a configurable penalty
+per scanner anomaly. A `ToolServerTrustTracker` accumulates per-server
+anomaly counts: if a tool server's outputs repeatedly trigger content
+analysis scanners, its future outputs start with lower effective trust.
+
+A `DecayAwareContext` wraps the standard `Context` and overrides the
+`min_trust` property to use effective trust. It can be passed to
+`Policy.evaluate` without changes to the policy engine, preserving
+backward compatibility.
 
 ---
 
@@ -695,34 +842,61 @@ This paper makes a deliberately narrow set of claims. We do not claim:
 ## 8. Reference implementation
 
 The reference implementation is Tessera, a Python library available at
-<https://github.com/kenithphilip/Tessera>. As of the time of writing:
+<https://github.com/kenithphilip/Tessera>. As of version 0.1.0:
 
-- **Source:** 1,556 lines of Python across 12 modules.
-- **Tests:** 1,187 lines of tests, 65 passing, including integration
-  tests against the real `mcp` Python package using in-memory transport.
+- **Source:** approximately 18,200 lines of Python across 92 modules.
+- **Rust gateway:** approximately 8,200 lines in `rust/tessera-gateway/`
+  (reference data plane).
+- **Tests:** approximately 15,700 lines of tests, 991 passing, runtime
+  approximately 2 minutes.
 - **Dependencies:** FastAPI and Pydantic (required), PyJWT with
-  cryptography (required for JWT-SVID signing), OpenTelemetry SDK
-  (optional for span emission), the `mcp` package (optional for MCP
-  interceptor).
+  cryptography (required for JWT-SVID signing). Optional extras for
+  OpenTelemetry, MCP, CEL, SPIFFE, gRPC/xDS, and 10 framework adapters.
 
-Key components:
+Key components (stable APIs):
 
 | Module | Purpose |
 |---|---|
-| `tessera.labels` | Signed TrustLabel structure, HMAC-SHA256 primitives |
+| `tessera.labels` | Signed TrustLabel, Origin, TrustLevel |
 | `tessera.signing` | JWTSigner, JWKSVerifier, HMACSigner, LabelSigner protocol |
-| `tessera.context` | LabeledSegment, Context, Spotlighting delimiter rendering |
-| `tessera.policy` | Taint-tracking policy engine with per-tool trust requirements |
-| `tessera.quarantine` | QuarantinedExecutor, strict_worker, safe-by-default WorkerReport |
-| `tessera.mcp` | MCP interceptor auto-labeling tool outputs |
-| `tessera.registry` | Org-level external-tool registry, registry-wins-on-inclusion |
+| `tessera.context` | LabeledSegment, Context, Spotlighting rendering |
+| `tessera.policy` | Taint-tracking policy engine with value-level accumulator |
+| `tessera.quarantine` | QuarantinedExecutor, strict_worker, WorkerReport |
+| `tessera.delegation` | DelegationToken, sign_delegation, verify_delegation |
+| `tessera.provenance` | ContextSegmentEnvelope, PromptProvenanceManifest |
 | `tessera.events` | Structured SecurityEvent with pluggable sinks |
-| `tessera.telemetry` | Optional OTel spans for proxy, MCP, policy, quarantine |
-| `tessera.proxy` | FastAPI sidecar reference implementation |
+| `tessera.taint` | TaintedValue, DependencyAccumulator, per-argument provenance |
+| `tessera.ir` | PolicyIR, YAML/JSON policy DSL, compile_policy |
 
-The deployment reference includes a SPIRE server, SPIRE agent, and
-example workload configuration demonstrating the JWT-SVID issuance and
-verification path.
+Content analysis and defense-in-depth:
+
+| Module | Purpose |
+|---|---|
+| `tessera.scanners.directive` | Two-layer directive detection (strong/ambient with model-targeting) |
+| `tessera.scanners.intent` | Intent verification (imperative action detection with tense/voice filtering) |
+| `tessera.scanners.heuristic` | Sliding-window injection scoring with target-qualified patterns |
+| `tessera.scanners.tool_output_schema` | Schema enforcement on tool output structural shape |
+| `tessera.output_monitor` | Token-level echo detection (URLs, IBANs, emails from untrusted segments) |
+| `tessera.claim_provenance` | Provenance-grounded response verification |
+| `tessera.plan_verifier` | Plan integrity verification (tool sequence vs user intent) |
+| `tessera.trust_decay` | Adaptive trust scoring with time decay and anomaly penalty |
+| `tessera.side_channels` | LoopGuard, StructuredResult, ConstantTimeDispatch |
+| `tessera.scanners.prompt_screen` | Initial prompt screening for delegated injection |
+
+Framework adapters (10):
+
+| Module | Framework |
+|---|---|
+| `tessera.adapters.langchain` | LangChain |
+| `tessera.adapters.openai_agents` | OpenAI Agents SDK |
+| `tessera.adapters.agentdojo` | AgentDojo |
+| `tessera.adapters.mcp_proxy` | MCP |
+| `tessera.adapters.crewai` | CrewAI |
+| `tessera.adapters.google_adk` | Google Agent Development Kit |
+| `tessera.adapters.llamaindex` | LlamaIndex |
+| `tessera.adapters.haystack` | Haystack |
+| `tessera.adapters.langgraph` | LangGraph |
+| `tessera.adapters.pydantic_ai` | PydanticAI |
 
 The test suite is the primary specification of the invariants claimed in
 Sections 3 and 4. Readers who want to verify the claims should read the
@@ -809,30 +983,48 @@ establish what content that actor is processing and where it came from.
 
 ## 11. Conclusion
 
-Two primitives, each implementable in approximately 200 lines of
-production code, close the two specific holes that recent agent security
-surveys identify as unimplemented in production systems. Neither primitive
-requires model modification, new hardware, or changes to control-plane
-infrastructure. Both have reference implementations with test-verified
-invariants and an AGPL-3.0-or-later license.
+The original version of this paper described two primitives, each
+implementable in approximately 200 lines, that close the two holes
+agent security surveys identify as unimplemented: trust-label injection
+and schema-enforced dual-LLM execution.
 
-The remaining work is not research. It is standardization (Section 9),
-adoption into production mesh data planes (Section 6), and the
-accompanying composition with identity, policy, sandboxing, and
-supply-chain verification at the other mesh layers. We expect that a
-deployment combining these primitives with an existing mesh (agentgateway
-or equivalent for the data plane, SPIRE for identity, Cedar or OPA for
-attribute-based policy, Firecracker or gVisor for sandboxing, and a
-standard OTel pipeline for observability) can provide defensible control-
-flow guarantees against indirect prompt injection within six months of
-focused integration work.
+This revision describes the extensions that grew from applying those
+primitives to the AgentDojo benchmark and from competitive analysis
+against CaMeL and Microsoft's Agent Governance Toolkit. The extensions
+address three attack classes the original primitives explicitly
+disclaimed:
 
-We are less interested in whether the reference implementation described
-in this paper becomes the adopted implementation, and more interested in
-whether the primitives themselves become widely understood as the minimum
-bar for any agent security mesh that claims to defend against indirect
-prompt injection. The survey literature is clear that the primitives are
-necessary. This paper shows that they are tractable.
+1. **Output manipulation** (the injection directs the model's text
+   response rather than its tool calls). Addressed by the directive
+   scanner's strong/ambient two-layer architecture, schema enforcement
+   on tool output structural shape, and intent verification with
+   tense/voice filtering.
+
+2. **Coarse-grained taint** (context-level min_trust blocks legitimate
+   tasks). Addressed by value-level taint tracking via
+   `DependencyAccumulator`, which traces per-argument provenance to
+   specific context segments.
+
+3. **Static trust** (trust levels never change). Addressed by adaptive
+   trust scoring with time decay and per-server anomaly penalties.
+
+Neither the original primitives nor these extensions require model
+modification, new hardware, or changes to control-plane infrastructure.
+All have reference implementations with test-verified invariants (991
+passing tests) and an AGPL-3.0-or-later license.
+
+The remaining work is validation: running the defenses against real
+models in real agent loops, not just deterministic replay. The replay
+evaluator measures what Tessera would block if the model followed the
+injection. It does not measure how often the model actually follows it.
+Live model evaluation against AgentDojo is the next step.
+
+We remain more interested in whether the primitives become widely
+understood as a minimum bar for agent security than in whether this
+specific implementation is adopted. The extensions described in this
+revision were driven by concrete benchmark gaps, not by architectural
+ambition. If a different implementation closes the same gaps with better
+tradeoffs, that is a good outcome.
 
 ---
 
@@ -859,6 +1051,43 @@ implementation should start with the following tests:
 - `tests/test_quarantine.py::test_planner_only_sees_trusted_segments`
 - `tests/test_events.py::test_worker_schema_violation_emits_event`
 
+**Value-level taint (Section 3.7):**
+
+- `tests/test_gap_analysis.py::TestArgumentTaintInPolicy::test_tainted_recipient_blocked_even_with_accumulator`
+- `tests/test_gap_analysis.py::TestArgumentTaintInPolicy::test_accumulator_blocks_on_clean_context_tainted_arg`
+- `tests/test_gap_analysis.py::TestArgumentTaintInPolicy::test_accumulator_not_checked_for_read_only_tools`
+
+**Content analysis (Section 3.8):**
+
+- `tests/test_gap_analysis.py::TestDirectiveScanner::test_speech_act_directive_detected`
+- `tests/test_gap_analysis.py::TestDirectiveScanner::test_ventriloquism_detected`
+- `tests/test_gap_analysis.py::TestDirectiveScanner::test_superlative_combined_with_speech_act_detected`
+- `tests/test_gap_analysis.py::TestIntentVerification::test_unrequested_send_flagged`
+- `tests/test_gap_analysis.py::TestIntentVerification::test_requested_action_not_flagged`
+- `tests/test_gap_analysis.py::TestOutputMonitoring::test_url_echo_detected`
+- `tests/test_gap_analysis.py::TestOutputMonitoring::test_user_mentioned_token_excluded`
+- `tests/test_tool_output_schema.py::TestSchemaEnforcement::test_prose_in_search_output_is_violation`
+- `tests/test_tool_output_schema.py::TestSchemaEnforcement::test_free_text_tool_never_violates`
+
+**False positive regression (scanner precision):**
+
+- `tests/test_scanner_false_positives.py::TestDirectiveFalsePositives::test_customer_service_advice`
+- `tests/test_scanner_false_positives.py::TestDirectiveFalsePositives::test_product_review_recommendation`
+- `tests/test_scanner_false_positives.py::TestIntentFalsePositives::test_past_tense_email_record`
+- `tests/test_scanner_false_positives.py::TestIntentFalsePositives::test_nominal_transfer`
+- `tests/test_scanner_false_positives.py::TestHeuristicFalsePositives::test_developer_todo_note`
+
+**Plan verification (Section 3.9):**
+
+- `tests/test_plan_verifier.py::test_search_prompt_forbids_send`
+- `tests/test_plan_verifier.py::test_forbidden_tool_detected`
+
+**Trust decay (Section 3.10):**
+
+- `tests/test_trust_decay.py::TestEffectiveTrust::test_decay_after_max_age`
+- `tests/test_trust_decay.py::TestEffectiveTrust::test_anomaly_penalty_applied`
+- `tests/test_trust_decay.py::TestDecayAwareContext::test_decay_aware_context_min_trust`
+
 **SPIFFE JWT-SVID signing:**
 
 - `tests/test_signing.py::test_jwt_round_trip`
@@ -866,7 +1095,16 @@ implementation should start with the following tests:
 - `tests/test_signing.py::test_jwks_verifier_resolves_by_kid`
 - `tests/test_signer_api.py::test_jwt_signer_via_make_segment_round_trips`
 
-Total passing tests at the time of writing: 65.
+**Delegation chain enforcement:**
+
+- `benchmarks/delegation_chain/test_delegation_attacks.py::TestDelegationScopeEnforcement::test_delegated_tool_outside_scope_denied`
+- `benchmarks/delegation_chain/test_delegation_attacks.py::TestDelegationScopeEnforcement::test_wrong_delegate_identity_denied`
+
+**Memory poisoning defense:**
+
+- `benchmarks/memory_poisoning/test_session_rescan.py::TestSessionRescan::test_poisoned_session_blocked_on_rescan`
+
+Total passing tests at the time of writing: 991.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tessera"
-version = "0.0.1"
+version = "0.1.0"
 description = "Signed provenance labels and taint-tracking policy for LLM context windows."
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
Paper revision (papers/two-primitives-for-agent-security-meshes.md): Updated from v0.1 to v0.2. Added four new sections: 3.7 (value-level taint tracking via DependencyAccumulator), 3.8 (content analysis with the directive/ambient two-layer architecture, intent verification with tense/voice filtering, and tool output schema enforcement), 3.9 (plan integrity verification), and 3.10 (adaptive trust scoring with time decay and anomaly penalties). Updated Section 2 threat model to acknowledge output manipulation defense-in-depth. Updated Section 3.5 to cross-reference 3.8. Updated Section 8 with current stats (18,200 lines, 92 modules, 991 tests, 10 framework adapters). Updated Section 11 conclusion to reflect the expanded scope and honest assessment of remaining validation work. Updated Appendix A with current test names across all defense layers (40 pinned tests).

Changelog (docs/CHANGELOG.md):
Added v0.1.0 entry with all new modules, changed behavior, and fixes. Added v0.0.1 entry with original primitives for historical reference.

README.md:
Updated badge to 991 tests. Added defense layers section (content analysis, output manipulation, trust decay, plan verification, side-channel mitigations, prompt screening). Added framework adapters section listing all 10 integrations. Updated module table with all new components.

pyproject.toml: version bumped from 0.0.1 to 0.1.0.